### PR TITLE
simply coverage report generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,7 @@ jobs:
 
     - name: Test
       run: |
-        go test -race -covermode=atomic -coverprofile cover.out ./...
-        cat cover.out >> coverage.txt
+        go test -race -covermode=atomic -coverprofile coverage.txt ./...
 
     - name: Upload Coverage report to CodeCov
       uses: codecov/codecov-action@v1.0.0


### PR DESCRIPTION
remove the extra step to cat the coverage file thats generated.