### PR TITLE
Do not require pass phrase in VolumeManager.CryptClose.

### DIFF
--- a/linux/lvm.go
+++ b/linux/lvm.go
@@ -56,7 +56,7 @@ func (ls *linuxLVM) CryptOpen(lvName string, key string) error {
 	return nil
 }
 
-func (ls *linuxLVM) CryptClose(lvName string, key string) error {
+func (ls *linuxLVM) CryptClose(lvName string) error {
 	return nil
 }
 

--- a/lvm.go
+++ b/lvm.go
@@ -41,8 +41,8 @@ type VolumeManager interface {
 	// key.
 	CryptOpen(lvName string, key string) error
 
-	// CryptClose close the encrypted logical volume using the provided key.
-	CryptClose(lvName string, key string) error
+	// CryptClose close the encrypted logical volume.
+	CryptClose(lvName string) error
 
 	// CreateLV creates a LV with specified name, size and type.
 	CreateLV(vgName string, name string, size uint64, lvType LVType) (LV, error)

--- a/mockos/lvm.go
+++ b/mockos/lvm.go
@@ -204,7 +204,7 @@ func (lvm *mockLVM) CryptOpen(lvName string, key string) error {
 	return nil
 }
 
-func (lvm *mockLVM) CryptClose(lvName string, key string) error {
+func (lvm *mockLVM) CryptClose(lvName string) error {
 	// NOOP
 	return nil
 }


### PR DESCRIPTION
Closing a luks device does not require a pass phrase.