### PR TITLE
Finish Lvm Impl

### DIFF
--- a/disk_test.go
+++ b/disk_test.go
@@ -1,23 +1,104 @@
 package disko_test
 
 import (
+	"fmt"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/anuvu/disko"
-	"github.com/stretchr/testify/assert"
 )
 
-func TestFreeSpace(t *testing.T) {
-	assert := assert.New(t)
-
-	values := [][]uint64{
-		{10, 10, 0},
-		{0, 200, 200},
-		{100, 200, 100},
+func TestFreeSpaceSize(t *testing.T) {
+	values := []struct{ start, end, expected uint64 }{
+		{0, 9, 10},
+		{0, 199, 200},
+		{100, 200, 101},
 	}
 
 	for _, v := range values {
-		f := disko.FreeSpace{v[0], v[1]}
-		assert.Equal(f.Size(), v[2])
+		f := disko.FreeSpace{v.start, v.end}
+		found := f.Size()
+
+		if v.expected != found {
+			t.Errorf("Size(%v) expected %d found %d",
+				f, v.expected, found)
+		}
+	}
+}
+
+func TestPartitionSize(t *testing.T) {
+	tables := []struct{ start, end, expected uint64 }{
+		{0, 99, 100},
+		{3 * disko.Mebibyte, (5000+3)*disko.Mebibyte - 1, 5000 * disko.Mebibyte},
+	}
+
+	for _, table := range tables {
+		p := disko.Partition{Start: table.start, End: table.end}
+		found := p.Size()
+
+		if table.expected != found {
+			t.Errorf("Size(%v) expected %d found %d", p, table.expected, found)
+		}
+	}
+}
+
+func TestDiskString(t *testing.T) {
+	mib := disko.Mebibyte
+	gb := uint64(1000 * 1000 * 1000) // nolint: gomnd
+
+	d := disko.Disk{
+		Name:       "sde",
+		Path:       "/dev/sde",
+		Size:       gb,
+		SectorSize: 512, //nolint: gomnd
+		Type:       disko.HDD,
+		Attachment: disko.ATA,
+		Partitions: disko.PartitionSet{
+			1: {Start: 3 * mib, End: 253*mib - 1, Number: 1},   //nolint: gomnd
+			3: {Start: 500 * mib, End: 600*mib - 1, Number: 3}, //nolint: gomnd
+		},
+		UdevInfo: disko.UdevInfo{},
+	}
+	found := " " + d.String() + " "
+
+	// disk size 1gb = 953 MiB. 600 = (253-3) + (953-600)
+	expectedFree := 600 // nolint: gomnd
+
+	for _, substr := range []string{
+		fmt.Sprintf("Size=%d", gb),
+		fmt.Sprintf("FreeSpace=%dMiB/2", expectedFree), //nolint: gomnd
+		fmt.Sprintf("NumParts=%d", len(d.Partitions))} {
+		if !strings.Contains(found, " "+substr+" ") {
+			t.Errorf("%s: missing expected substring ' %s '", found, substr)
+		}
+	}
+}
+
+func TestDiskDetails(t *testing.T) {
+	mib := disko.Mebibyte
+	d := disko.Disk{
+		Name:       "sde",
+		Path:       "/dev/sde",
+		Size:       mib * mib,
+		SectorSize: 512, //nolint: gomnd
+		Type:       disko.HDD,
+		Attachment: disko.ATA,
+		Partitions: disko.PartitionSet{
+			1: {Start: 3 * mib, End: 253*mib - 1, Number: 1}, //nolint: gomnd
+		},
+		UdevInfo: disko.UdevInfo{},
+	}
+	expected := `
+[ # Start End Size Name ]
+[ 1 3 MiB 253 MiB 250 MiB                 ]
+[ - 253 MiB 1048575 MiB 1048322 MiB <free> ]`
+
+	spaces := regexp.MustCompile("[ ]+")
+	found := strings.TrimSpace(spaces.ReplaceAllString(d.Details(), " "))
+	expShort := strings.TrimSpace(spaces.ReplaceAllString(expected, " "))
+
+	if expShort != found {
+		t.Errorf("Expected: '%s'\nFound: '%s'\n", expShort, found)
 	}
 }

--- a/disko.go
+++ b/disko.go
@@ -1,4 +1,4 @@
 package disko
 
 // Mebibyte defines 1MiB
-const Mebibyte = 1024 * 1024
+const Mebibyte uint64 = 1024 * 1024

--- a/linux/disk.go
+++ b/linux/disk.go
@@ -152,29 +152,6 @@ func findPartitions(fp io.ReadSeeker) (disko.PartitionSet, uint, error) {
 	return parts, uint(ssize), nil
 }
 
-func freeSpacesWithMin(d disko.Disk, minSize uint64) []disko.FreeSpace {
-	// Stay out of the first 1Mebibyte
-	// Leave 33 sectors at end (for GPT second header) and round 1MiB down.
-	//nolint: gomnd
-	end := ((d.Size - uint64(d.SectorSize*33)/disko.Mebibyte) * disko.Mebibyte)
-	used := []uRange{{0, 1*disko.Mebibyte - 1}, {end, d.Size}}
-	avail := []disko.FreeSpace{}
-
-	for _, p := range d.Partitions {
-		used = append(used, uRange{p.Start, p.End})
-	}
-
-	for _, g := range findRangeGaps(used, 0, d.Size) {
-		if g.Size() < minSize {
-			continue
-		}
-
-		avail = append(avail, disko.FreeSpace(g))
-	}
-
-	return avail
-}
-
 func getDiskNames() ([]string, error) {
 	realDiskKnameRegex := regexp.MustCompile("^((s|v|xv|h)d[a-z]|nvme[0-9]n[0-9]+)$")
 	disks := []string{}

--- a/linux/system.go
+++ b/linux/system.go
@@ -84,7 +84,7 @@ func (ls *linuxSystem) ScanDisk(devicePath string) (disko.Disk, error) {
 		name = path.Base(devicePath)
 		blockdev = false
 	} else {
-		bss, err := getBlockDevSize(devicePath)
+		bss, err := getBlockSize(devicePath)
 		if err != nil {
 			return disko.Disk{}, nil
 		}

--- a/linux/system.go
+++ b/linux/system.go
@@ -138,7 +138,6 @@ func (ls *linuxSystem) ScanDisk(devicePath string) (disko.Disk, error) {
 		disk.SectorSize = ssize
 	}
 
-	disk.FreeSpaces = freeSpacesWithMin(disk, disko.ExtentSize)
 	disk.Partitions = parts
 
 	return disk, nil

--- a/linux/util.go
+++ b/linux/util.go
@@ -217,7 +217,7 @@ func findRangeGaps(ranges []uRange, min, max uint64) []uRange {
 	return ret
 }
 
-func getBlockDevSize(dev string) (uint64, error) {
+func getBlockSize(dev string) (uint64, error) {
 	path := path.Join("/sys/block", path.Base(dev), "queue/logical_block_size")
 
 	content, err := ioutil.ReadFile(path)
@@ -231,7 +231,7 @@ func getBlockDevSize(dev string) (uint64, error) {
 	if err != nil {
 		return uint64(0),
 			errors.Wrapf(err,
-				"getBlockDevSize(%s): failed to convert '%s' to int", dev, d)
+				"getBlockSize(%s): failed to convert '%s' to int", dev, d)
 	}
 
 	return uint64(v), nil

--- a/linux/util.go
+++ b/linux/util.go
@@ -169,54 +169,6 @@ func pathExists(d string) bool {
 	return true
 }
 
-type uRange struct {
-	Start, End uint64
-}
-
-func (r *uRange) Size() uint64 {
-	return r.End - r.Start
-}
-
-// findRangeGaps returns a set of uRange to represent the un-used
-// uint64 between min and max that are not included in ranges.
-//  findRangeGaps({{10, 40}, {50, 100}}, 0, 110}) ==
-//      {{0, 9}, {41, 49}, {101, 110}}
-func findRangeGaps(ranges []uRange, min, max uint64) []uRange {
-	// start 'ret' off with full range of min to max, then start cutting it up.
-	ret := []uRange{{min, max}}
-
-	for _, i := range ranges {
-		for r := 0; r < len(ret); r++ {
-			// 5 cases:
-			if i.Start > ret[r].End || i.End < ret[r].Start {
-				// a. i has no overlap
-			} else if i.Start <= ret[r].Start && i.End >= ret[r].End {
-				// b.) i is complete superset, so remove ret[r]
-				ret = append(ret[:r], ret[r+1:]...)
-				r--
-			} else if i.Start > ret[r].Start && i.End < ret[r].End {
-				// c.) i is strict subset: split ret[r]
-				ret = append(
-					append(ret[:r+1], uRange{i.End + 1, ret[r].End}),
-					ret[r+1:]...)
-				ret[r].End = i.Start - 1
-				r++ // added entry is guaranteed to be 'a', so skip it.
-			} else if i.Start <= ret[r].Start {
-				// d.) overlap left edge to middle
-				ret[r].Start = i.End + 1
-			} else if i.Start <= ret[r].End {
-				// e.) middle to right edge (possibly past).
-				ret[r].End = i.Start - 1
-			} else {
-				panic(fmt.Sprintf("Error in findRangeGaps: %v, r=%d, ret=%v",
-					i, r, ret))
-			}
-		}
-	}
-
-	return ret
-}
-
 func getBlockSize(dev string) (uint64, error) {
 	path := path.Join("/sys/block", path.Base(dev), "queue/logical_block_size")
 

--- a/linux/util.go
+++ b/linux/util.go
@@ -260,3 +260,7 @@ func getFileSize(file *os.File) (uint64, error) {
 func lvPath(vgName, lvName string) string {
 	return path.Join("/dev", vgName, lvName)
 }
+
+func vgLv(vgName, lvName string) string {
+	return path.Join(vgName, lvName)
+}

--- a/linux/util.go
+++ b/linux/util.go
@@ -264,3 +264,23 @@ func lvPath(vgName, lvName string) string {
 func vgLv(vgName, lvName string) string {
 	return path.Join(vgName, lvName)
 }
+
+// Ceiling returns the smallest integer equal to or larger than val that is evenly
+// divisible by unit.
+func Ceiling(val, unit uint64) uint64 {
+	if val%unit == 0 {
+		return val
+	}
+
+	return ((val + unit) / unit) * unit
+}
+
+// Floor returns the largest integer equal to or less than val that is evenly
+// divisible by unit.
+func Floor(val, unit uint64) uint64 {
+	if val%unit == 0 {
+		return val
+	}
+
+	return (val / unit) * unit
+}

--- a/linux/util_test.go
+++ b/linux/util_test.go
@@ -10,69 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFindGaps0(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{{0, 100}},
-		findRangeGaps([]uRange{}, 0, 100))
-}
-
-func TestFindGaps1(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{{0, 49}, {60, 100}},
-		findRangeGaps([]uRange{{50, 59}}, 0, 100))
-}
-
-func TestFindGaps2(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{{51, 100}},
-		findRangeGaps([]uRange{{0, 50}}, 0, 100))
-}
-
-func TestFindGaps3(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{{0, 10}},
-		findRangeGaps([]uRange{{11, 100}}, 0, 100))
-}
-
-func TestFindGaps4(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{{0, 10}, {50, 59}, {91, 100}},
-		findRangeGaps([]uRange{{11, 49}, {60, 90}}, 0, 100))
-}
-
-func TestFindGaps5(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{},
-		findRangeGaps([]uRange{{0, 10}, {11, 100}}, 0, 100))
-}
-
-func TestFindGaps6(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{},
-		findRangeGaps([]uRange{{0, 150}, {50, 100}}, 100, 100))
-}
-
-func TestFindGaps7(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{{0, 9}, {41, 49}, {101, 110}},
-		findRangeGaps([]uRange{{10, 40}, {50, 100}}, 0, 110))
-}
-
-func TestFindGaps8(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{{10, 100}},
-		findRangeGaps([]uRange{{110, 200}}, 10, 100))
-}
-
 //nolint: lll
 func TestParseUdevInfo(t *testing.T) {
 	data := []byte(`P: /devices/virtual/block/dm-0

--- a/linux/util_test.go
+++ b/linux/util_test.go
@@ -194,3 +194,25 @@ func TestRunCommand(t *testing.T) {
 	assert.Nil(runCommand("sh", "-c", "exit 0"))
 	assert.NotNil(runCommand("sh", "-c", "exit 1"))
 }
+
+func TestCeilingUp(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(uint64(100), Ceiling(98, 4)) //nolint: gomnd
+}
+
+func TestCeilingEven(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(uint64(100), Ceiling(100, 4)) //nolint: gomnd
+	assert.Equal(uint64(97), Ceiling(97, 1))   //nolint: gomnd
+}
+
+func TestFloorDown(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(uint64(96), Floor(98, 4)) //nolint: gomnd
+}
+
+func TestFloorEven(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(uint64(100), Floor(100, 4)) //nolint: gomnd
+	assert.Equal(uint64(97), Floor(97, 1))   //nolint: gomnd
+}

--- a/linux/virt_test.go
+++ b/linux/virt_test.go
@@ -1,0 +1,65 @@
+package linux
+
+import (
+	"fmt"
+	"testing"
+)
+
+type myDetector struct {
+	out      []byte
+	err      []byte
+	rc       int
+	expected virtType
+	logged   string
+}
+
+func (d *myDetector) detectVirt() ([]byte, []byte, int) {
+	return d.out, d.err, d.rc
+}
+
+func (d *myDetector) logf(format string, a ...interface{}) {
+	d.logged = fmt.Sprintf(format, a...)
+}
+
+func TestVirtType(t *testing.T) {
+	tables := []myDetector{
+		{[]byte("none\n"), []byte{}, 1, virtNone, ""},
+		{[]byte("unknown\n"), []byte{}, 0, virtUnknown, ""},
+		{[]byte("none\n"), []byte{}, 0, virtNone, ""},
+		{[]byte("kvm\n"), []byte{}, 0, virtKvm, ""},
+		{[]byte("error\n"), []byte{}, 0, virtError, ""},
+		{[]byte("qemu\n"), []byte{}, 0, virtQemu, ""},
+		{[]byte("zvm\n"), []byte{}, 0, virtZvm, ""},
+		{[]byte("vmware\n"), []byte{}, 0, virtVmware, ""},
+		{[]byte("microsoft\n"), []byte{}, 0, virtMicrosoft, ""},
+		{[]byte("oracle\n"), []byte{}, 0, virtOracle, ""},
+		{[]byte("xen\n"), []byte{}, 0, virtXen, ""},
+		{[]byte("bochs\n"), []byte{}, 0, virtBochs, ""},
+		{[]byte("uml\n"), []byte{}, 0, virtUml, ""},
+		{[]byte("parallels\n"), []byte{}, 0, virtParallels, ""},
+		{[]byte("bhyve\n"), []byte{}, 0, virtBhyve, ""},
+		{[]byte("not-known-yet\n"), []byte{}, 0, virtUnknown, ""},
+		{[]byte("unexpected\n"), []byte("error"), 3, virtError, ""},
+	}
+
+	for _, td := range tables {
+		// set it back to unset so cache is not used.
+		systemVirtType = virtUnset
+		td := td
+		found := getVirtTypeIface(&td)
+
+		if found != td.expected {
+			t.Errorf("out=%s err=%s rc=%d returned %d (%s) expected %s",
+				td.out, td.err, td.rc,
+				found, found.String(), td.expected.String())
+		}
+	}
+
+	systemVirtType = virtOracle
+	found := getVirtType()
+
+	if found != virtOracle {
+		t.Errorf("value not cached in systemVirtType. found %s expected %s\n",
+			string(found), string(virtOracle))
+	}
+}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,51 @@
+package disko
+
+import "fmt"
+
+type uRange struct {
+	Start, End uint64
+}
+
+func (r *uRange) Size() uint64 {
+	return r.End - r.Start
+}
+
+// findRangeGaps returns a set of uRange to represent the un-used
+// uint64 between min and max that are not included in ranges.
+//  findRangeGaps({{10, 40}, {50, 100}}, 0, 110}) ==
+//      {{0, 9}, {41, 49}, {101, 110}}
+func findRangeGaps(ranges []uRange, min, max uint64) []uRange {
+	// start 'ret' off with full range of min to max, then start cutting it up.
+	ret := []uRange{{min, max}}
+
+	for _, i := range ranges {
+		for r := 0; r < len(ret); r++ {
+			// 5 cases:
+			if i.Start > ret[r].End || i.End < ret[r].Start {
+				// a. i has no overlap
+			} else if i.Start <= ret[r].Start && i.End >= ret[r].End {
+				// b.) i is complete superset, so remove ret[r]
+				ret = append(ret[:r], ret[r+1:]...)
+				r--
+			} else if i.Start > ret[r].Start && i.End < ret[r].End {
+				// c.) i is strict subset: split ret[r]
+				ret = append(
+					append(ret[:r+1], uRange{i.End + 1, ret[r].End}),
+					ret[r+1:]...)
+				ret[r].End = i.Start - 1
+				r++ // added entry is guaranteed to be 'a', so skip it.
+			} else if i.Start <= ret[r].Start {
+				// d.) overlap left edge to middle
+				ret[r].Start = i.End + 1
+			} else if i.Start <= ret[r].End {
+				// e.) middle to right edge (possibly past).
+				ret[r].End = i.Start - 1
+			} else {
+				panic(fmt.Sprintf("Error in findRangeGaps: %v, r=%d, ret=%v",
+					i, r, ret))
+			}
+		}
+	}
+
+	return ret
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,70 @@
+package disko
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindGaps0(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(
+		[]uRange{{0, 100}},
+		findRangeGaps([]uRange{}, 0, 100))
+}
+
+func TestFindGaps1(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(
+		[]uRange{{0, 49}, {60, 100}},
+		findRangeGaps([]uRange{{50, 59}}, 0, 100))
+}
+
+func TestFindGaps2(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(
+		[]uRange{{51, 100}},
+		findRangeGaps([]uRange{{0, 50}}, 0, 100))
+}
+
+func TestFindGaps3(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(
+		[]uRange{{0, 10}},
+		findRangeGaps([]uRange{{11, 100}}, 0, 100))
+}
+
+func TestFindGaps4(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(
+		[]uRange{{0, 10}, {50, 59}, {91, 100}},
+		findRangeGaps([]uRange{{11, 49}, {60, 90}}, 0, 100))
+}
+
+func TestFindGaps5(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(
+		[]uRange{},
+		findRangeGaps([]uRange{{0, 10}, {11, 100}}, 0, 100))
+}
+
+func TestFindGaps6(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(
+		[]uRange{},
+		findRangeGaps([]uRange{{0, 150}, {50, 100}}, 100, 100))
+}
+
+func TestFindGaps7(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(
+		[]uRange{{0, 9}, {41, 49}, {101, 110}},
+		findRangeGaps([]uRange{{10, 40}, {50, 100}}, 0, 110))
+}
+
+func TestFindGaps8(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(
+		[]uRange{{10, 100}},
+		findRangeGaps([]uRange{{110, 200}}, 10, 100))
+}


### PR DESCRIPTION
This finishes the implementation of lvm interface by adding
CreateLV, ExtendLV, HasLV, RemoveLV.

Notes:
 * HasLV will panic if it's ScanLV fails.
 * CreateLV and ExtendLV require size to be unit of extent size.
   I'd rather have the operation error than arbitrarily round
   up or down.

Also adds Ceiling and Floor functions that can be used in calling CreateLV
and ExtendLV.

    createLv("vg0", "lv0", Ceiling(mysize, lvm.ExtentSize) lvm.THICK)