### PR TITLE
findRangeGaps: fix bug if input was not sorted.

### DIFF
--- a/disk.go
+++ b/disk.go
@@ -92,7 +92,7 @@ func (d *Disk) FreeSpacesWithMin(minSize uint64) []FreeSpace {
 	// Stay out of the first 1Mebibyte
 	// Leave 33 sectors at end (for GPT second header) and round 1MiB down.
 	end := ((d.Size - uint64(d.SectorSize)*33) / Mebibyte) * Mebibyte
-	used := []uRange{{0, 1*Mebibyte - 1}, {end, d.Size}}
+	used := uRanges{{0, 1*Mebibyte - 1}, {end, d.Size}}
 
 	for _, p := range d.Partitions {
 		used = append(used, uRange{p.Start, p.End})

--- a/util.go
+++ b/util.go
@@ -1,6 +1,9 @@
 package disko
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 type uRange struct {
 	Start, End uint64
@@ -10,13 +13,22 @@ func (r *uRange) Size() uint64 {
 	return r.End - r.Start
 }
 
+type uRanges []uRange
+
+func (r uRanges) Len() int           { return len(r) }
+func (r uRanges) Less(i, j int) bool { return r[i].Start < r[j].Start }
+func (r uRanges) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+
 // findRangeGaps returns a set of uRange to represent the un-used
 // uint64 between min and max that are not included in ranges.
 //  findRangeGaps({{10, 40}, {50, 100}}, 0, 110}) ==
 //      {{0, 9}, {41, 49}, {101, 110}}
-func findRangeGaps(ranges []uRange, min, max uint64) []uRange {
+// Note that input list will be sorted.
+func findRangeGaps(ranges uRanges, min, max uint64) uRanges {
 	// start 'ret' off with full range of min to max, then start cutting it up.
-	ret := []uRange{{min, max}}
+	ret := uRanges{{min, max}}
+
+	sort.Sort(ranges)
 
 	for _, i := range ranges {
 		for r := 0; r < len(ret); r++ {

--- a/util_test.go
+++ b/util_test.go
@@ -6,65 +6,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFindGaps0(t *testing.T) {
+func TestFindGaps(t *testing.T) {
 	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{{0, 100}},
-		findRangeGaps([]uRange{}, 0, 100))
-}
+	type data struct {
+		expected uRanges
+		ranges   uRanges
+		min, max uint64
+	}
 
-func TestFindGaps1(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{{0, 49}, {60, 100}},
-		findRangeGaps([]uRange{{50, 59}}, 0, 100))
-}
-
-func TestFindGaps2(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{{51, 100}},
-		findRangeGaps([]uRange{{0, 50}}, 0, 100))
-}
-
-func TestFindGaps3(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{{0, 10}},
-		findRangeGaps([]uRange{{11, 100}}, 0, 100))
-}
-
-func TestFindGaps4(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{{0, 10}, {50, 59}, {91, 100}},
-		findRangeGaps([]uRange{{11, 49}, {60, 90}}, 0, 100))
-}
-
-func TestFindGaps5(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{},
-		findRangeGaps([]uRange{{0, 10}, {11, 100}}, 0, 100))
-}
-
-func TestFindGaps6(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{},
-		findRangeGaps([]uRange{{0, 150}, {50, 100}}, 100, 100))
-}
-
-func TestFindGaps7(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{{0, 9}, {41, 49}, {101, 110}},
-		findRangeGaps([]uRange{{10, 40}, {50, 100}}, 0, 110))
-}
-
-func TestFindGaps8(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(
-		[]uRange{{10, 100}},
-		findRangeGaps([]uRange{{110, 200}}, 10, 100))
+	for _, d := range []data{
+		{uRanges{{0, 100}}, uRanges{}, 0, 100},
+		{uRanges{{0, 49}, {60, 100}}, uRanges{{50, 59}}, 0, 100},
+		{uRanges{{51, 100}}, uRanges{{0, 50}}, 0, 100},
+		{uRanges{{0, 10}}, uRanges{{11, 100}}, 0, 100},
+		{uRanges{{0, 10}, {50, 59}, {91, 100}},
+			uRanges{{11, 49}, {60, 90}}, 0, 100},
+		{uRanges{}, uRanges{{0, 10}, {11, 100}}, 0, 100},
+		{uRanges{}, uRanges{{0, 150}, {50, 100}}, 100, 100},
+		{uRanges{{0, 9}, {41, 49}, {101, 110}},
+			uRanges{{10, 40}, {50, 100}}, 0, 110},
+		{uRanges{{10, 100}}, uRanges{{110, 200}}, 10, 100},
+		{uRanges{{0, 9}, {51, 89}}, uRanges{{90, 100}, {10, 50}}, 0, 100},
+		{uRanges{{2, 3}, {26, 52}, {62, 98}},
+			uRanges{{0, 1}, {99, 100}, {53, 61}, {4, 25}}, 0, 100},
+	} {
+		assert.Equal(d.expected, findRangeGaps(d.ranges, d.min, d.max))
+	}
 }


### PR DESCRIPTION
findRangeGaps assumed sorted input (by start).
This caused a bug when summing available space as walking
the PartitionSet is not guaranteed order.