### PR TITLE
Add name of VG into LV on create

### DIFF
--- a/mockos/lvm.go
+++ b/mockos/lvm.go
@@ -264,6 +264,7 @@ func (lvm *mockLVM) CreateLV(vgName string, name string, size uint64,
 		Name:      name,
 		Size:      size,
 		Type:      lvType,
+		VGName:    vgName,
 		Encrypted: false,
 	}
 


### PR DESCRIPTION
LV should have the name of vg when it's creating. This  resolves an issue in atom side to maintain the VGs and their corresponding LVs 