### PR TITLE
Replace newGPTTable with use of gpt.NewTable, silence a lint warning.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/pkg/errors v0.9.1
-	github.com/rekby/gpt v0.0.0-20190209220743-520ac65554cf
+	github.com/rekby/gpt v0.0.0-20200219180433-a930afbc6edc
 	github.com/rekby/mbr v0.0.0-20190325193910-2b19b9cdeebc
 	github.com/satori/go.uuid v1.2.0
 	github.com/smartystreets/goconvey v1.6.4

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rekby/gpt v0.0.0-20190209220743-520ac65554cf h1:cFRSGvObVNqtA4pnu8Y/0CWxc4WFvfssCVTrslH/yg4=
 github.com/rekby/gpt v0.0.0-20190209220743-520ac65554cf/go.mod h1:scrOqOnnHVKCHENvFw8k9ajCb88uqLQDA4BvuJNJ2ew=
+github.com/rekby/gpt v0.0.0-20200219180433-a930afbc6edc h1:goZGTwEEn8mWLcY012VouWZWkJ8GrXm9tS3VORMxT90=
+github.com/rekby/gpt v0.0.0-20200219180433-a930afbc6edc/go.mod h1:scrOqOnnHVKCHENvFw8k9ajCb88uqLQDA4BvuJNJ2ew=
 github.com/rekby/mbr v0.0.0-20190325193910-2b19b9cdeebc h1:LIhcsQ01OzuCmjqcggpWhs8GBGNqVPycFbBpY3suBbI=
 github.com/rekby/mbr v0.0.0-20190325193910-2b19b9cdeebc/go.mod h1:omSwqul59wlKxf3OVbxhOiSjxM1at3GsfDbgnghKyeA=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=

--- a/linux/disk_test.go
+++ b/linux/disk_test.go
@@ -69,7 +69,7 @@ func TestGetAttachType(t *testing.T) {
 
 func genTempGptDisk(tmpd string) (disko.Disk, error) {
 	fpath := path.Join(tmpd, "mydisk")
-	fsize := uint64(200 * 1024 * 1024) // nolint:gomnd (200MiB)
+	fsize := uint64(200 * 1024 * 1024) // nolint:gomnd
 
 	disk := disko.Disk{
 		Name:       "mydisk",
@@ -116,7 +116,7 @@ func TestMyPartition(t *testing.T) {
 	defer os.RemoveAll(tmpd)
 
 	fpath := path.Join(tmpd, "mydisk")
-	fsize := uint64(200 * 1024 * 1024) // nolint:gomnd (200MiB)
+	fsize := uint64(200 * 1024 * 1024) // nolint:gomnd
 
 	if err := ioutil.WriteFile(fpath, []byte{}, 0644); err != nil {
 		t.Fatalf("Failed to write to a temp file: %s", err)


### PR DESCRIPTION
2 things here:
 * Replace newGPTTable with gpt.NewTable from the gpt module.
 * Silence a //nolint lint warning.