### PR TITLE
Drop linux build constraint.

### DIFF
--- a/linux/disk.go
+++ b/linux/disk.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package linux
 
 import (

--- a/linux/disk_test.go
+++ b/linux/disk_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package linux
 
 import (

--- a/linux/lvm.go
+++ b/linux/lvm.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package linux
 
 import (

--- a/linux/lvm_test.go
+++ b/linux/lvm_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package linux
 
 import (

--- a/linux/lvmdump.go
+++ b/linux/lvmdump.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package linux
 
 import (

--- a/linux/system.go
+++ b/linux/system.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package linux
 
 import (

--- a/linux/util.go
+++ b/linux/util.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package linux
 
 import (

--- a/linux/util_test.go
+++ b/linux/util_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package linux
 
 import (

--- a/linux/virt.go
+++ b/linux/virt.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package linux
 
 import "log"


### PR DESCRIPTION
There was a build constraint (// +build linux) on the linux package,
but that should not have been needed.

The build constraint meant that you could not run the tests on MacOS.