### PR TITLE
Change AttachmentType and DiskType to marshal to json as string.

### DIFF
--- a/disk.go
+++ b/disk.go
@@ -23,6 +23,48 @@ func (t DiskType) String() string {
 	return []string{"HDD", "SSD", "NVME"}[t]
 }
 
+// StringToDiskType - convert a string to a disk type.
+func StringToDiskType(typeStr string) DiskType {
+	kmap := map[string]DiskType{
+		"HDD":  HDD,
+		"SSD":  SSD,
+		"NVME": NVME,
+	}
+	if dtype, ok := kmap[typeStr]; ok {
+		return dtype
+	}
+
+	return HDD
+}
+
+// MarshalJSON - Custom to marshal as a string.
+func (t *DiskType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
+}
+
+// UnmarshalJSON - custom to read as string or int.
+func (t *DiskType) UnmarshalJSON(b []byte) error {
+	var err error
+	var asStr string
+	var asInt int
+
+	err = json.Unmarshal(b, &asInt)
+	if err == nil {
+		*t = DiskType(asInt)
+		return nil
+	}
+
+	err = json.Unmarshal(b, &asStr)
+	if err != nil {
+		return err
+	}
+
+	dtype := StringToDiskType(asStr)
+	*t = dtype
+
+	return nil
+}
+
 // AttachmentType enumerates the type of device to which the disks are
 // attached to in the system.
 type AttachmentType int
@@ -56,6 +98,53 @@ const (
 func (t AttachmentType) String() string {
 	return []string{"UNKNOWN", "RAID", "SCSI", "ATA", "PCIE", "USB",
 		"VIRTIO", "IDE"}[t]
+}
+
+// StringToAttachmentType - Convert a string to an AttachmentType
+func StringToAttachmentType(atypeStr string) AttachmentType {
+	kmap := map[string]AttachmentType{
+		"UNKNOWN": UnknownAttach,
+		"RAID":    RAID,
+		"SCSI":    SCSI,
+		"ATA":     ATA,
+		"PCIE":    PCIE,
+		"VIRTIO":  VIRTIO,
+		"IDE":     IDE,
+	}
+
+	if atype, ok := kmap[atypeStr]; ok {
+		return atype
+	}
+
+	return UnknownAttach
+}
+
+// MarshalJSON - Custom to marshal as a string.
+func (t *AttachmentType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
+}
+
+// UnmarshalJSON - reverse of the custom marshler
+func (t *AttachmentType) UnmarshalJSON(b []byte) error {
+	var err error
+	var asStr string
+	var asInt int
+
+	err = json.Unmarshal(b, &asInt)
+	if err == nil {
+		*t = AttachmentType(asInt)
+		return nil
+	}
+
+	err = json.Unmarshal(b, &asStr)
+	if err != nil {
+		return err
+	}
+
+	dtype := StringToAttachmentType(asStr)
+	*t = dtype
+
+	return nil
 }
 
 // PartType represents a GPT Partition GUID


### PR DESCRIPTION
Strings are more readable.  This adds support for Unmarshalling as
either a string or an int.  Having strings are nice for just dumping json
as a representation to show things.

When we encode the following disk to json:

    disko.Disk{
        Name: "sda", Path: "/dev/sda",
        Size: 500*1024*1024, SectorSize: 512,
        Type: disko.HDD,
        Attachment: disko.ATA}

Here is before and after.   Note that attachment and type are now strings rather than ints.  Also, note that we can still un-serialize from integer or string.

    --- Before ----         | ---- After -----
    {                       | {
      "name": "sda",        |   "name": "sda",
      "path": "/dev/sda",   |   "path": "/dev/sda",
      "size": 524288000,    |   "size": 524288000,
      "sectorSize": 512,    |   "sectorsize": 512,
      "type": 0,            |   "type": "HDD",
      "attachment": 3       |   "attachment": "ATA"
    }                       | }

@rchamarthy I'd like your thoughts on this... if we are using marshalJson on these objects out of REST api then maybe this is a bad idea.   But, even then... its not like 'type: 0' means much.
