### PR TITLE
cli: add megaraid disk-summary

### DIFF
--- a/demo/main.go
+++ b/demo/main.go
@@ -1,11 +1,42 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 )
+
+func printTextTable(data [][]string) {
+	var lengths = make([]int, len(data[0]))
+
+	for _, line := range data {
+		for i, field := range line {
+			if len(field) > lengths[i] {
+				lengths[i] = len(field)
+			}
+		}
+	}
+
+	fmts := make([]string, len(lengths))
+
+	for i, l := range lengths {
+		fmts[i] = fmt.Sprintf("%%-%ds", l)
+	}
+
+	pfmt := strings.Join(fmts, " | ") + " |\n"
+
+	for _, line := range data {
+		s := make([]interface{}, len(line))
+		for i, v := range line {
+			s[i] = v
+		}
+
+		fmt.Printf(pfmt, s...)
+	}
+}
 
 func main() {
 	app := &cli.App{

--- a/demo/megaraid.go
+++ b/demo/megaraid.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"path"
+	"path/filepath"
 	"strconv"
 
 	"github.com/anuvu/disko/megaraid"
@@ -19,7 +21,81 @@ var megaraidCommands = cli.Command{
 			Usage:  "Dump information about megaraid",
 			Action: megaraidDump,
 		},
+		{
+			Name:   "disk-summary",
+			Usage:  "Show information about virtual devices on system",
+			Action: megaraidDiskSummary,
+		},
 	},
+}
+
+func megaraidNameByDiskID(id int) (string, error) {
+	// given ID, we expect a single file in:
+	// <mrSysPath>/0000:05:00.0/host0/target0:0:<ID>/0:0:<ID>:0/block/
+	mrSysPath := "/sys/bus/pci/drivers/megaraid_sas"
+	idStr := fmt.Sprintf("%d", id)
+	blkDir := mrSysPath + "/*/host*/target0:0:" + idStr + "/0:0:" + idStr + ":0/block/*"
+	matches, err := filepath.Glob(blkDir)
+
+	if err != nil {
+		return "", err
+	}
+
+	if len(matches) != 1 {
+		return "", fmt.Errorf("found %d matches to %s", len(matches), blkDir)
+	}
+
+	return path.Base(matches[0]), nil
+}
+
+func megaraidDiskSummary(c *cli.Context) error {
+	var err error
+	var ctrlNum = 0
+	var ctrlArg = c.Args().First()
+
+	if ctrlArg != "" {
+		ctrlNum, err = strconv.Atoi(ctrlArg)
+		if err != nil {
+			return fmt.Errorf("could not convert to integer: %s", err)
+		}
+	}
+
+	mraid := megaraid.StorCli()
+	ctrl, err := mraid.Query(ctrlNum)
+
+	if err != nil {
+		return err
+	}
+
+	data := [][]string{{"Path", "Name", "Type", "State"}}
+
+	for _, vd := range ctrl.VirtDrives {
+		stype := "HDD"
+
+		if ctrl.DriveGroups[vd.DriveGroup].IsSSD() {
+			stype = "SSD"
+		}
+
+		data = append(data, []string{vd.Path, vd.RaidName, stype, vd.Raw["State"]})
+	}
+
+	for _, d := range ctrl.Drives {
+		if d.DriveGroup >= 0 {
+			continue
+		}
+
+		path := ""
+		if bname, err := megaraidNameByDiskID(d.ID); err == nil {
+			path = "/dev/" + bname
+		}
+
+		data = append(data, []string{path, fmt.Sprintf("diskid-%d", d.ID),
+			d.MediaType.String(), d.State})
+	}
+
+	printTextTable(data)
+
+	return nil
 }
 
 func megaraidDump(c *cli.Context) error {


### PR DESCRIPTION
megaraid disk-summary shows information about virtual disks and disks
that are not in a disk group.

So virtual disks show up like:

    $ ./demo megaraid disk-summary
    Path     | Name    | Type | State |
    /dev/sda | RAID0_2 | SSD  | Optl  |
    /dev/sdb | RAID0_3 | HDD  | Optl  |

JBOD or "UBUnsp" (bad) disks show up like:

    $ ./demo megaraid disk-summary
    Path     | Name      | Type | State  |
             | diskid-13 | HDD  | UBUnsp |
    /dev/sda | diskid-8  | HDD  | JBOD   |
    /dev/sdb | diskid-10 | HDD  | JBOD   |