### PR TITLE
Connect megaraid to linux System.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/anuvu/disko
 go 1.13
 
 require (
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/rekby/gpt v0.0.0-20200219180433-a930afbc6edc
 	github.com/rekby/mbr v0.0.0-20190325193910-2b19b9cdeebc

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/linux/system.go
+++ b/linux/system.go
@@ -8,14 +8,18 @@ import (
 	"syscall"
 
 	"github.com/anuvu/disko"
+	"github.com/anuvu/disko/megaraid"
 )
 
 type linuxSystem struct {
+	megaraid megaraid.MegaRaid
 }
 
 // System returns an linux specific implementation of disko.System interface.
 func System() disko.System {
-	return &linuxSystem{}
+	return &linuxSystem{
+		megaraid: megaraid.CachingStorCli(),
+	}
 }
 
 func (ls *linuxSystem) ScanAllDisks(filter disko.DiskFilter) (disko.DiskSet, error) {
@@ -94,7 +98,7 @@ func (ls *linuxSystem) ScanDisk(devicePath string) (disko.Disk, error) {
 		return disko.Disk{}, err
 	}
 
-	diskType, err := getDiskType(udInfo)
+	diskType, err := ls.getDiskType(devicePath, udInfo)
 	if err != nil {
 		return disko.Disk{}, err
 	}
@@ -159,4 +163,23 @@ func (ls *linuxSystem) DeletePartition(d disko.Disk, number uint) error {
 
 func (ls *linuxSystem) Wipe(d disko.Disk) error {
 	return nil
+}
+
+func (ls *linuxSystem) getDiskType(path string, udInfo disko.UdevInfo) (disko.DiskType, error) {
+	ctrl, err := ls.megaraid.Query(0)
+	if err == nil {
+		for _, vd := range ctrl.VirtDrives {
+			if vd.Path == path {
+				if ctrl.DriveGroups[vd.DriveGroup].IsSSD() {
+					return disko.SSD, nil
+				}
+
+				return disko.HDD, nil
+			}
+		}
+	} else if err != megaraid.ErrNoStorcli && err != megaraid.ErrNoController {
+		return disko.HDD, err
+	}
+
+	return getDiskType(udInfo)
 }


### PR DESCRIPTION
This connects the linux disko.System() interface with a storCli
implementation.  The end result is that now we get improved answers
for the DiskType of a Disk.  If the disk is a virtual megaraid drive
whose DiskGroup is entirely made up of ssd, then you will now see
that its DiskTypetype is SSD.

It is hooked up through go-cache to avoid repeated queries of 'storcli'.
That isn't *slow*, but not fast either.  The assumption is that
those things dont' change very often.  The timeout is set to 5 minutes
here.