### PR TITLE
Change custom MarshalJson to take objects not pointers.

### DIFF
--- a/disk.go
+++ b/disk.go
@@ -38,7 +38,7 @@ func StringToDiskType(typeStr string) DiskType {
 }
 
 // MarshalJSON - Custom to marshal as a string.
-func (t *DiskType) MarshalJSON() ([]byte, error) {
+func (t DiskType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.String())
 }
 
@@ -120,7 +120,7 @@ func StringToAttachmentType(atypeStr string) AttachmentType {
 }
 
 // MarshalJSON - Custom to marshal as a string.
-func (t *AttachmentType) MarshalJSON() ([]byte, error) {
+func (t AttachmentType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.String())
 }
 
@@ -364,8 +364,8 @@ func (p *Partition) UnmarshalJSON(b []byte) error {
 }
 
 // MarshalJSON - serialize to json
-func (p *Partition) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&jPartition{
+func (p Partition) MarshalJSON() ([]byte, error) {
+	return json.Marshal(jPartition{
 		Start:  p.Start,
 		Last:   p.Last,
 		ID:     p.ID.String(),

--- a/megaraid/megaraid.go
+++ b/megaraid/megaraid.go
@@ -61,7 +61,7 @@ type DriveGroupSet map[int]*DriveGroup
 
 // MarshalJSON - serialize to json.  Custom Marshal to only reference Disks
 // by ID not by full dump.
-func (dgs *DriveGroupSet) MarshalJSON() ([]byte, error) {
+func (dgs DriveGroupSet) MarshalJSON() ([]byte, error) {
 	type terseDriveGroupSet struct {
 		ID     int
 		Drives []int
@@ -69,7 +69,7 @@ func (dgs *DriveGroupSet) MarshalJSON() ([]byte, error) {
 
 	var mySet = []terseDriveGroupSet{}
 
-	for id, driveSet := range *dgs {
+	for id, driveSet := range dgs {
 		drives := []int{}
 		for drive := range driveSet.Drives {
 			drives = append(drives, drive)
@@ -123,7 +123,7 @@ func (t MediaType) String() string {
 }
 
 // MarshalJSON for string output rather than int
-func (t *MediaType) MarshalJSON() ([]byte, error) {
+func (t MediaType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.String())
 }
 


### PR DESCRIPTION
When dumping json of a DiskSet, I was not getting the custom
MarshalJson on the Disks it contained.  This change seems to
allow to json.MarshalIndent(<diskSet>) and have the strings
output inside, and same for partitions and other things.