### PR TITLE
Fix getPartitionsBlockDevice when provided a name rather than path.

### DIFF
--- a/linux/disk.go
+++ b/linux/disk.go
@@ -235,8 +235,8 @@ func getPartitionsBlockDevice(dev string) (string, error) {
 
 	_, err = ioutil.ReadFile(fmt.Sprintf("%s/%s", syspath, "partition"))
 	if err != nil {
-		// this is a block device itself, no /sys/class/block/<dev>/partition
-		return filepath.EvalSymlinks(dev)
+		// dev is a block device, there is no /sys/class/block/<dev>/partition
+		return path.Base(syspath), nil
 	}
 
 	// evalSymlinks on a partition will return


### PR DESCRIPTION
Previously getPartitionsBlockDevice("sda") was broken while
getPartitionsBlockDevice("/dev/sda") would work.  This just fixes
the broken case.

Closes #24