### PR TITLE
Fix ScanVGs in linux to correctly populate PVs.

### DIFF
--- a/linux/lvm.go
+++ b/linux/lvm.go
@@ -57,7 +57,7 @@ func (ls *linuxLVM) ScanVGs(filter disko.VGFilter) (disko.VGSet, error) {
 			continue
 		}
 
-		pvs, err := ls.ScanPVs(getPVFilterByName(name))
+		pvs, err := ls.ScanPVs(func(p disko.PV) bool { return p.VGName == name })
 		if err != nil {
 			return vgs, err
 		}


### PR DESCRIPTION
Just a thinko/typo meant that PVs were not getting populated
when scanning VGs.