### PR TITLE
Correctly populate RAID into attachment type for MegaRaid disks.

### DIFF
--- a/demo/megaraid.go
+++ b/demo/megaraid.go
@@ -3,8 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"path"
-	"path/filepath"
 	"strconv"
 
 	"github.com/anuvu/disko/megaraid"
@@ -27,25 +25,6 @@ var megaraidCommands = cli.Command{
 			Action: megaraidDiskSummary,
 		},
 	},
-}
-
-func megaraidNameByDiskID(id int) (string, error) {
-	// given ID, we expect a single file in:
-	// <mrSysPath>/0000:05:00.0/host0/target0:0:<ID>/0:0:<ID>:0/block/
-	mrSysPath := "/sys/bus/pci/drivers/megaraid_sas"
-	idStr := fmt.Sprintf("%d", id)
-	blkDir := mrSysPath + "/*/host*/target0:0:" + idStr + "/0:0:" + idStr + ":0/block/*"
-	matches, err := filepath.Glob(blkDir)
-
-	if err != nil {
-		return "", err
-	}
-
-	if len(matches) != 1 {
-		return "", fmt.Errorf("found %d matches to %s", len(matches), blkDir)
-	}
-
-	return path.Base(matches[0]), nil
 }
 
 func megaraidDiskSummary(c *cli.Context) error {
@@ -85,7 +64,7 @@ func megaraidDiskSummary(c *cli.Context) error {
 		}
 
 		path := ""
-		if bname, err := megaraidNameByDiskID(d.ID); err == nil {
+		if bname, err := megaraid.NameByDiskID(d.ID); err == nil {
 			path = "/dev/" + bname
 		}
 

--- a/linux/system.go
+++ b/linux/system.go
@@ -103,13 +103,18 @@ func (ls *linuxSystem) ScanDisk(devicePath string) (disko.Disk, error) {
 		return disko.Disk{}, err
 	}
 
+	attachType := getAttachType(udInfo)
+	if megaraid.IsMegaRaidSysPath(udInfo.Properties["DEVPATH"]) {
+		attachType = disko.RAID
+	}
+
 	disk := disko.Disk{
 		Name:       name,
 		Path:       devicePath,
 		SectorSize: ssize,
 		UdevInfo:   udInfo,
 		Type:       diskType,
-		Attachment: getAttachType(udInfo),
+		Attachment: attachType,
 	}
 
 	fh, err := os.Open(devicePath)

--- a/megaraid/linux.go
+++ b/megaraid/linux.go
@@ -1,0 +1,83 @@
+package megaraid
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+const sysDriverMegaRaidSAS = "/sys/bus/pci/drivers/megaraid_sas"
+
+// IsMegaRaidSysPath - is this sys path (udevadm info's DEVPATH) on a megaraid controller.
+//  syspath will look something like
+//     /devices/pci0000:3a/0000:3a:02.0/0000:3c:00.0/host0/target0:2:2/0:2:2:0/block/sdc
+func IsMegaRaidSysPath(syspath string) bool {
+	if !strings.HasPrefix(syspath, "/sys") {
+		syspath = "/sys" + syspath
+	}
+
+	if !strings.Contains(syspath, "/host") {
+		return false
+	}
+
+	fp, err := filepath.EvalSymlinks(syspath)
+	if err != nil {
+		fmt.Printf("seriously? %s\n", err)
+		return false
+	}
+
+	for _, path := range getSysPaths() {
+		if strings.HasPrefix(fp, path) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// NameByDiskID - return the linux name (sda) for the disk with given DiskID
+func NameByDiskID(id int) (string, error) {
+	// given ID, we expect a single file in:
+	// <sysDriverMegaRaidSAS>/0000:05:00.0/host0/target0:0:<ID>/0:0:<ID>:0/block/
+	idStr := fmt.Sprintf("%d", id)
+	blkDir := sysDriverMegaRaidSAS + "/*/host*/target0:0:" + idStr + "/0:0:" + idStr + ":0/block/*"
+	matches, err := filepath.Glob(blkDir)
+
+	if err != nil {
+		return "", err
+	}
+
+	if len(matches) != 1 {
+		return "", fmt.Errorf("found %d matches to %s", len(matches), blkDir)
+	}
+
+	return path.Base(matches[0]), nil
+}
+
+func getSysPaths() []string {
+	paths := []string{}
+	// sysDriverMegaRaidSAS has directory entries for each of the scsi hosts on that controller.
+	//   $cd /sys/bus/pci/drivers/megaraid_sas
+	//   $ for d in *; do [ -d "$d" ] || continue; echo "$d -> $( cd "$d" && pwd -P )"; done
+	//    0000:3c:00.0 -> /sys/devices/pci0000:3a/0000:3a:02.0/0000:3c:00.0
+	//    module -> /sys/module/megaraid_sas
+
+	// We take a hack path and consider anything with a ":" in that dir as a host path.
+	matches, err := filepath.Glob(sysDriverMegaRaidSAS + "/*:*")
+
+	if err != nil {
+		fmt.Printf("errors: %s\n", err)
+		return paths
+	}
+
+	for _, p := range matches {
+		fp, err := filepath.EvalSymlinks(p)
+
+		if err == nil {
+			paths = append(paths, fp)
+		}
+	}
+
+	return paths
+}


### PR DESCRIPTION
Previously Scan would not ever list RAID as the Attachment Type.
This gets that populated for Megaraid disks.