### PR TITLE
Add lvm UUID to VG, LV, PV.  Add a LVType THINPOOL.

### DIFF
--- a/linux/lvm.go
+++ b/linux/lvm.go
@@ -296,11 +296,22 @@ func (d *lvmLVData) toLV() disko.LV {
 
 	lvtype := disko.THICK
 
+	var isThin, isPool = false, false
+
 	for _, l := range strings.Split(d.raw["lv_layout"], ",") {
 		if l == "thin" {
-			lvtype = disko.THIN
-			break
+			isThin = true
 		}
+
+		if l == "pool" {
+			isPool = true
+		}
+	}
+
+	if isPool {
+		lvtype = disko.THINPOOL
+	} else if isThin {
+		lvtype = disko.THIN
 	}
 
 	if pathExists(d.Path) {

--- a/linux/lvm.go
+++ b/linux/lvm.go
@@ -49,6 +49,7 @@ func (ls *linuxLVM) ScanVGs(filter disko.VGFilter) (disko.VGSet, error) {
 		name := vgd.Name
 		vg := disko.VG{
 			Name:      name,
+			UUID:      vgd.UUID,
 			Size:      vgd.Size,
 			FreeSpace: vgd.Free,
 		}
@@ -311,6 +312,7 @@ func (d *lvmLVData) toLV() disko.LV {
 
 	lv := disko.LV{
 		Name:      d.Name,
+		UUID:      d.UUID,
 		Path:      d.Path,
 		VGName:    d.VGName,
 		Size:      d.Size,
@@ -324,6 +326,7 @@ func (d *lvmLVData) toLV() disko.LV {
 func (d *lvmPVData) toPV() disko.PV {
 	return disko.PV{
 		Path:     d.Path,
+		UUID:     d.UUID,
 		Name:     path.Base(d.Path),
 		Size:     d.Size,
 		VGName:   d.VGName,

--- a/linux/lvm_test.go
+++ b/linux/lvm_test.go
@@ -31,6 +31,7 @@ func TestLVDataToLV(t *testing.T) {
 			Name:      "myvol0",
 			Path:      "/dev/myvg0/myvol0",
 			VGName:    "myvg0",
+			UUID:      "iFMHAp-24c3-LENS-0IFt-4Mhj-rvhf-kBnnuS",
 			Size:      mySize,
 			Type:      disko.THICK,
 			Encrypted: false,

--- a/linux/lvm_test.go
+++ b/linux/lvm_test.go
@@ -4,37 +4,94 @@ import (
 	"testing"
 
 	"github.com/anuvu/disko"
-	"github.com/stretchr/testify/assert"
 )
 
+//nolint: funlen
 func TestLVDataToLV(t *testing.T) {
 	var mySize uint64 = 10 * 1024 * 1024
+	const aUUID = "iFMHAp-24c3-LENS-0IFt-4Mhj-rvhf-kBnnuS"
 
-	assert := assert.New(t)
-
-	lvd := lvmLVData{
-		Name:   "myvol0",
-		VGName: "myvg0",
-		Path:   "/dev/myvg0/myvol0",
-		Size:   mySize,
-		UUID:   "iFMHAp-24c3-LENS-0IFt-4Mhj-rvhf-kBnnuS",
-		Active: true,
-		Pool:   "ThinDataLV",
-		raw: map[string]string{
-			"lv_layout": "linear",
+	for i, d := range []struct {
+		input    lvmLVData
+		expected disko.LV
+	}{
+		{
+			input: lvmLVData{
+				Name:   "myvol0",
+				VGName: "myvg0",
+				Path:   "/dev/myvg0/myvol0",
+				Size:   mySize,
+				UUID:   aUUID,
+				Active: true,
+				Pool:   "ThinDataLV",
+				raw: map[string]string{
+					"lv_layout": "linear",
+				},
+			},
+			expected: disko.LV{
+				Name:      "myvol0",
+				Path:      "/dev/myvg0/myvol0",
+				VGName:    "myvg0",
+				UUID:      aUUID,
+				Size:      mySize,
+				Type:      disko.THICK,
+				Encrypted: false,
+			},
 		},
+		{
+			input: lvmLVData{
+				Name:   "myvol0",
+				VGName: "myvg0",
+				Path:   "/dev/myvg0/myvol0",
+				Size:   mySize,
+				UUID:   aUUID,
+				Active: true,
+				Pool:   "ThinDataLV",
+				raw: map[string]string{
+					"lv_layout": "thin,sparse",
+				},
+			},
+			expected: disko.LV{
+				Name:      "myvol0",
+				Path:      "/dev/myvg0/myvol0",
+				VGName:    "myvg0",
+				UUID:      aUUID,
+				Size:      mySize,
+				Type:      disko.THIN,
+				Encrypted: false,
+			},
+		},
+		{
+			input: lvmLVData{
+				Name:   "ThinDataLV",
+				VGName: "vg_ifc0",
+				Path:   "",
+				Size:   mySize,
+				UUID:   aUUID,
+				Active: true,
+				Pool:   "",
+				raw: map[string]string{
+					"lv_layout":   "thin,pool",
+					"lv_path":     "",
+					"lv_dm_path":  "/dev/mapper/vg_ifc0-ThinDataLV",
+					"data_lv":     "[ThinDataLV_tdata]",
+					"metadata_lv": "[ThinDataLV_tmeta]",
+				},
+			},
+			expected: disko.LV{
+				Name:      "ThinDataLV",
+				Path:      "",
+				VGName:    "vg_ifc0",
+				UUID:      aUUID,
+				Size:      mySize,
+				Type:      disko.THINPOOL,
+				Encrypted: false,
+			},
+		},
+	} {
+		found := d.input.toLV()
+		if found != d.expected {
+			t.Errorf("entry %d found != expected\n%v\n%v\n", i, found, d.expected)
+		}
 	}
-
-	assert.Equal(
-		lvd.toLV(),
-		disko.LV{
-			Name:      "myvol0",
-			Path:      "/dev/myvg0/myvol0",
-			VGName:    "myvg0",
-			UUID:      "iFMHAp-24c3-LENS-0IFt-4Mhj-rvhf-kBnnuS",
-			Size:      mySize,
-			Type:      disko.THICK,
-			Encrypted: false,
-		},
-	)
 }

--- a/lvm.go
+++ b/lvm.go
@@ -135,6 +135,9 @@ const (
 
 	// THIN indicates thinly provisioned logical volume.
 	THIN
+
+	// THINPOOL indicates a pool lv for other lvs
+	THINPOOL
 )
 
 func (t LVType) String() string {

--- a/lvm.go
+++ b/lvm.go
@@ -67,6 +67,9 @@ type PV struct {
 	// Name returns the name of the PV.
 	Name string `json:"name"`
 
+	// UUID for the PV
+	UUID string `json:"uuid"`
+
 	// Path returns the device path of the PV.
 	Path string `json:"path"`
 
@@ -95,6 +98,9 @@ const ExtentSize = 4 * Mebibyte
 type LV struct {
 	// Name is the name of the logical volume.
 	Name string `json:"name"`
+
+	// UUID for the LV
+	UUID string `json:"uuid"`
 
 	// Path is the full path of the logical volume.
 	Path string `json:"path"`
@@ -141,6 +147,9 @@ func (t LVType) String() string {
 type VG struct {
 	// Name is the name of the volume group.
 	Name string `json:"name"`
+
+	// UUID for the VG
+	UUID string `json:"uuid"`
 
 	// Size is the current size of the volume group.
 	Size uint64 `json:"size"`


### PR DESCRIPTION
UUID is helpful in identifying a lvm item, as it is the
guaranteed-unique identifier for a VG, LV, PV.

Add THINPOOL as an LVType.