### PR TITLE
RemoveVG: fix bug where it attempted to remove an lv, not vg.

### DIFF
--- a/linux/lvm.go
+++ b/linux/lvm.go
@@ -174,7 +174,7 @@ func (ls *linuxLVM) ExtendVG(vgName string, pvs ...disko.PV) error {
 }
 
 func (ls *linuxLVM) RemoveVG(vgName string) error {
-	return runCommand("lvm", "lvremove", "--force", vgName)
+	return runCommand("lvm", "vgremove", "--force", vgName)
 }
 
 func (ls *linuxLVM) HasVG(vgName string) bool {


### PR DESCRIPTION
Simple copy-paste error here. RemoveVG should call
 lvm vgremove
not
 lvm lvremove