### PR TITLE
fix CreatePV to use name and path

### DIFF
--- a/linux/lvm.go
+++ b/linux/lvm.go
@@ -114,10 +114,28 @@ func (ls *linuxLVM) ScanLVs(filter disko.LVFilter) (disko.LVSet, error) {
 	return lvs, nil
 }
 
-func (ls *linuxLVM) CreatePV(name string) (disko.PV, error) {
-	nilPV := disko.PV{}
+func makeDevPathFromName(name string) string {
+	if strings.HasPrefix(name, "/dev/") {
+		return name
+	}
 
-	err := runCommandSettled("lvm", "pvcreate", "--zero=y", name)
+	return "/dev/" + name
+}
+
+func makeDevNameFromPath(path string) string {
+	if strings.HasPrefix(path, "/dev/") {
+		return path[len("/dev/"):]
+	}
+
+	return path
+}
+
+func (ls *linuxLVM) CreatePV(nameOrPath string) (disko.PV, error) {
+	nilPV := disko.PV{}
+	path := makeDevPathFromName(nameOrPath)
+	name := makeDevNameFromPath(nameOrPath)
+
+	err := runCommandSettled("lvm", "pvcreate", "--zero=y", path)
 
 	if err != nil {
 		return nilPV, err


### PR DESCRIPTION
CreatePV accepts a path but thinks it can accept a name and uses the
param as a name to later find the PV it just created. The scan fails to
match and CreatePV always returns an error saying it did not find the PV
it just successfully created.

Fix: accept name or path, if name is given make a path and if path is
given make a name and then use both appropriately

Signed-off-by: Ravi Chamarthy <ravchama@cisco.com>