### PR TITLE
make correct kname and path for createPV

### DIFF
--- a/linux/disk.go
+++ b/linux/disk.go
@@ -192,11 +192,12 @@ func getPathForKname(kname string) string {
 }
 
 func getKnameAndPathForBlockDevice(nameOrPath string) (string, string, error) {
-	var kname, path string
-
-	if kname, err := getSysPathForBlockDevicePath(nameOrPath); err != nil {
-		return kname, path, err
+	syspath, err := getSysPathForBlockDevicePath(nameOrPath)
+	if err != nil {
+		return "", "", err
 	}
+
+	kname := path.Base(syspath)
 
 	return kname, getPathForKname(kname), nil
 }


### PR DESCRIPTION
fixes the getKnameAndPathForBlockDevice to accept either a path or a
name, find the device name and return the device name and path the way
kernel sees it.

Signed-off-by: Ravi Chamarthy <ravchama@cisco.com>