### PR TITLE
Allow passing arguments to report functions, and use where possible.

### DIFF
--- a/linux/lvmdump.go
+++ b/linux/lvmdump.go
@@ -61,9 +61,11 @@ func parsePvReport(report []byte) ([]lvmPVData, error) {
 	return d["report"][0]["pv"], nil
 }
 
-func getPvReport() ([]lvmPVData, error) {
-	out, stderr, rc := runCommandWithOutputErrorRc(
-		"lvm", "pvs", "--options=pv_all,vg_name", "--report-format=json", "--unit=B")
+func getPvReport(args ...string) ([]lvmPVData, error) {
+	cmd := []string{"lvm", "pvs", "--options=pv_all,vg_name", "--report-format=json", "--unit=B"}
+	cmd = append(cmd, args...)
+	out, stderr, rc := runCommandWithOutputErrorRc(cmd...)
+
 	if rc != 0 {
 		return []lvmPVData{},
 			fmt.Errorf("failed lvm pvs [%d]: %s\n%s", rc, out, stderr)
@@ -108,9 +110,10 @@ func parseVgReport(report []byte) ([]lvmVGData, error) {
 	return d["report"][0]["vg"], nil
 }
 
-func getVgReport() ([]lvmVGData, error) {
-	out, stderr, rc := runCommandWithOutputErrorRc(
-		"lvm", "vgs", "--options=vg_all", "--report-format=json", "--unit=B")
+func getVgReport(args ...string) ([]lvmVGData, error) {
+	cmd := []string{"lvm", "vgs", "--options=vg_all", "--report-format=json", "--unit=B"}
+	cmd = append(cmd, args...)
+	out, stderr, rc := runCommandWithOutputErrorRc(cmd...)
 
 	if rc != 0 {
 		return []lvmVGData{},
@@ -162,9 +165,10 @@ func parseLvReport(report []byte) ([]lvmLVData, error) {
 	return d["report"][0]["lv"], nil
 }
 
-func getLvReport() ([]lvmLVData, error) {
-	out, stderr, rc := runCommandWithOutputErrorRc(
-		"lvm", "lvs", "--options=lv_all,vg_name", "--report-format=json", "--unit=B")
+func getLvReport(args ...string) ([]lvmLVData, error) {
+	cmd := []string{"lvm", "lvs", "--options=lv_all,vg_name", "--report-format=json", "--unit=B"}
+	cmd = append(cmd, args...)
+	out, stderr, rc := runCommandWithOutputErrorRc(cmd...)
 
 	if rc != 0 {
 		return []lvmLVData{},


### PR DESCRIPTION
This adds passing arguments to
 getPvReport
 getLvReport
 getVgReport

And then uses those to not get full lvm reports when only one device
is expected.

The big win is that the CreateLV, CreatePV, CreateVG functions
no longer do a scan of all  of lvm after doing their job.  They
specifically ask about the device they know they created.