### PR TITLE
Add demo 'misc' subcommand and minor changes

### DIFF
--- a/demo/disk.go
+++ b/demo/disk.go
@@ -91,7 +91,7 @@ func diskShow(c *cli.Context) error {
 			return err
 		}
 
-		fmt.Printf("%s\n", disk.Details())
+		fmt.Printf("%s\n%s\n", disk.String(), disk.Details())
 
 		return nil
 	}
@@ -108,7 +108,7 @@ func diskShow(c *cli.Context) error {
 	}
 
 	for _, d := range disks {
-		fmt.Printf("%s\n", d.Details())
+		fmt.Printf("%s\n%s\n", d.String(), d.Details())
 	}
 
 	return nil

--- a/demo/main.go
+++ b/demo/main.go
@@ -46,6 +46,7 @@ func main() {
 			&diskCommands,
 			&megaraidCommands,
 			&lvmCommands,
+			&miscCommands,
 		},
 	}
 

--- a/demo/misc.go
+++ b/demo/misc.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/anuvu/disko"
+	"github.com/anuvu/disko/linux"
+	"github.com/anuvu/disko/partid"
+	"github.com/urfave/cli/v2"
+)
+
+const partitionName = "updown"
+const maxParts = 128
+
+//nolint:gochecknoglobals
+var miscCommands = cli.Command{
+	Name:  "misc",
+	Usage: "miscellaneous test/debug",
+	Subcommands: []*cli.Command{
+		{
+			Name:   "updown",
+			Usage:  "Create a partition table, vg, lv, take it all down",
+			Action: miscUpDown,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "skip-lvm",
+					Value: false,
+					Usage: "Do not do lvm operations",
+				},
+				&cli.BoolFlag{
+					Name:  "skip-pvcreate",
+					Value: false,
+					Usage: "Do not do pvcreate separately from vgcreate",
+				},
+				&cli.BoolFlag{
+					Name:  "skip-partition",
+					Value: false,
+					Usage: "Do not create and remove partition in the loop",
+				},
+				&cli.IntFlag{
+					Name:  "loops",
+					Value: 1,
+					Usage: fmt.Sprintf("Do not create a partition - requires one named '%s'", partitionName),
+				},
+			},
+		},
+	},
+}
+
+func pathExists(fpath string) bool {
+	_, err := os.Stat(fpath)
+	if err != nil && os.IsNotExist(err) {
+		return false
+	}
+
+	return true
+}
+
+func findPartInfo(diskPath string) (disko.Partition, error) {
+	const mysize = 200 * disko.Mebibyte //nolint: gomnd
+	var err error
+
+	mysys := linux.System()
+
+	disk, err := mysys.ScanDisk(diskPath)
+	if err != nil {
+		return disko.Partition{}, fmt.Errorf("failed to scan %s: %s", diskPath, err)
+	}
+
+	// try to find by name (previous failed run)
+	for i := uint(1); i < maxParts; i++ {
+		if disk.Partitions[i].Name == partitionName {
+			fmt.Printf("Using existing partition number %d with name %s.\n", i, partitionName)
+			return disk.Partitions[i], nil
+		}
+	}
+
+	// no --part-number given or --part-number=0 - find a number and space.
+	partNum := uint(maxParts)
+
+	for i := uint(1); i < maxParts; i++ {
+		if _, ok := disk.Partitions[i]; !ok {
+			partNum = i
+			break
+		}
+	}
+
+	if partNum == maxParts {
+		return disko.Partition{}, fmt.Errorf("unable to find empty partition number on %s", disk.Path)
+	}
+
+	fss := disk.FreeSpacesWithMin(mysize)
+	if len(fss) < 1 {
+		return disko.Partition{}, fmt.Errorf("did not find usable freespace on %s", disk.Path)
+	}
+
+	part := disko.Partition{
+		Type:   partid.LinuxLVM,
+		Name:   partitionName,
+		ID:     disko.GenGUID(),
+		Number: partNum,
+		Start:  fss[0].Start,
+		Last:   fss[0].Start + mysize - 1,
+	}
+
+	return part, nil
+}
+
+//nolint: gocognit, funlen
+func miscUpDown(c *cli.Context) error {
+	fname := c.Args().First()
+
+	var err error
+	var numRuns = c.Int("loops")
+	var doLvm = !c.Bool("skip-lvm")
+	var doCreatePV = !c.Bool("skip-pvcreate")
+	var doPartition = !c.Bool("skip-partition")
+	var part disko.Partition
+	var pv disko.PV
+	var vg disko.VG
+	var lv disko.LV
+
+	if fname == "" {
+		return fmt.Errorf("must provide disk/file to partition")
+	}
+
+	part, err = findPartInfo(fname)
+	if err != nil {
+		return err
+	}
+
+	mysys := linux.System()
+	myvmgr := linux.VolumeManager()
+
+	disk, err := mysys.ScanDisk(fname)
+
+	if err != nil {
+		return fmt.Errorf("failed to scan %s: %s", fname, err)
+	}
+
+	partPath := fmt.Sprintf("%s%d", disk.Path, part.Number)
+	partName := fmt.Sprintf("%s%d", path.Base(disk.Path), part.Number)
+
+	if doPartition {
+		if pathExists(partPath) {
+			if err = mysys.DeletePartition(disk, part.Number); err != nil {
+				return err
+			}
+
+			fmt.Printf("deleted existing partition %d on %s\n", part.Number, disk.Path)
+		}
+	} else if !pathExists(partPath) {
+		err = mysys.CreatePartition(disk, part)
+		if err != nil {
+			return err
+		}
+		delPart := func() {
+			if pathExists(partPath) {
+				fmt.Printf("Deleting partition %s %d\n", disk.Path, part.Number)
+				if err := mysys.DeletePartition(disk, part.Number); err != nil {
+					fmt.Printf("that went bad: %s\n", err)
+				}
+			}
+		}
+
+		defer delPart()
+	}
+
+	if disk, err = mysys.ScanDisk(fname); err != nil {
+		return err
+	}
+
+	fmt.Printf("numruns=%d partition=%t createpv=%t lvm=%t\n%s\n",
+		numRuns, doPartition, doCreatePV, doLvm, disk.Details())
+
+	for i := 0; i < numRuns; i++ {
+		fmt.Printf("[%d] starting %s %d\n", i, disk.Path, part.Number)
+
+		if doPartition {
+			err = mysys.CreatePartition(disk, part)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("[%d] created partition %d\n", i, part.Number)
+		}
+
+		if !pathExists(partPath) {
+			fmt.Printf("partition path %s did not exist.", partPath)
+
+			return fmt.Errorf("should have existed")
+		}
+
+		if doLvm {
+			if doCreatePV {
+				pv, err = myvmgr.CreatePV(partPath)
+				if err != nil {
+					fmt.Printf("failed to createPV(%s): %s", partPath, err)
+					return err
+				}
+
+				fmt.Printf("[%d] created PV %s: %v\n", i, partPath, pv.UUID)
+			} else {
+				pv = disko.PV{Name: partName, Path: partPath}
+			}
+
+			vg, err = myvmgr.CreateVG("myvg0", pv)
+			if err != nil {
+				fmt.Printf("Failed creating vg on %s\n", pv.Name)
+
+				return err
+			}
+
+			fmt.Printf("[%d] created VG %s\n", i, "myvg0")
+
+			lv, err = myvmgr.CreateLV(vg.Name, "mylv0", 100*disko.Mebibyte, disko.THICK) //nolint: gomnd
+			if err != nil {
+				fmt.Printf("Failed creating lv %s on %s\n", "mylv0", "myvg0")
+
+				return err
+			}
+
+			fmt.Printf("[%d] created LV %s/%s (%d)\n", i, vg.Name, lv.Name, lv.Size/disko.Mebibyte)
+
+			err = myvmgr.RemoveVG(vg.Name)
+			if err != nil {
+				fmt.Printf("Failed removing vg %s: %s\n", "mylv0", err)
+				return err
+			}
+
+			err = myvmgr.DeletePV(pv)
+			if err != nil {
+				fmt.Printf("failed to DeletePV(%s): %s\n", partPath, err)
+				return err
+			}
+
+			fmt.Printf("[%d] deleted PV %s\n", i, partPath)
+		}
+
+		if doPartition {
+			err = mysys.DeletePartition(disk, part.Number)
+			if err != nil {
+				return err
+			}
+
+			if pathExists(partPath) {
+				fmt.Printf("After DeletePartition %d, %s did exist.", part.Number, partPath)
+				return fmt.Errorf("should not have existed")
+			}
+
+			fmt.Printf("[%d] deleted partition %s\n", i, partPath)
+		}
+	}
+
+	return nil
+}

--- a/linux/disk.go
+++ b/linux/disk.go
@@ -435,16 +435,52 @@ func deletePartitions(d disko.Disk, pNums []uint) error {
 		return fmt.Errorf("failed to stat %s: %s", d.Path, err)
 	}
 
+	// Call delpart only if this is a block device.
 	if info.Mode()&os.ModeDevice != 0 {
-		// Call partx if this is a block device.
 		for _, pNum := range pNums {
-			if err := runCommand("partx", "--delete", fmt.Sprintf("%d", pNum), d.Path); err != nil {
+			partPath := getPartPathForKname(d.Name, pNum)
+
+			if exists, err := blockDeviceExists(partPath); err != nil {
+				return fmt.Errorf("failed to stat %s part %d (%s): %s", d.Name, pNum, partPath, err)
+			} else if !exists {
+				continue
+			}
+
+			if err = runCommand("delpart", d.Path, fmt.Sprintf("%d", pNum)); err != nil {
 				return err
 			}
 		}
 	}
 
-	return err
+	return nil
+}
+
+func blockDeviceExists(bpath string) (bool, error) {
+	info, err := os.Stat(bpath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return info.Mode()&os.ModeDevice != 0, nil
+}
+
+func getPartKname(diskName string, num uint) string {
+	endsWithNum := regexp.MustCompile("[0-9]$")
+	sep := ""
+
+	if endsWithNum.MatchString(diskName) {
+		sep = "p"
+	}
+
+	return fmt.Sprintf("%s%s%d", diskName, sep, num)
+}
+
+func getPartPathForKname(diskName string, num uint) string {
+	return getPathForKname(getPartKname(diskName, num))
 }
 
 // writeProtectiveMBR - add a ProtectiveMBR spanning the disk.

--- a/linux/disk.go
+++ b/linux/disk.go
@@ -351,7 +351,6 @@ func addPartitionSet(d disko.Disk, pSet disko.PartitionSet) error {
 		return err
 	}
 
-	pnums := []uint{}
 	maxEnd := ((d.Size - uint64(d.SectorSize)*33) / disko.Mebibyte) * disko.Mebibyte
 	minStart := disko.Mebibyte
 
@@ -371,8 +370,6 @@ func addPartitionSet(d disko.Disk, pSet disko.PartitionSet) error {
 		if err := zeroStartEnd(fp, int64(p.Start), int64(p.Last)); err != nil {
 			return fmt.Errorf("failed to zero partition %d: %s", p.Number, err)
 		}
-
-		pnums = append(pnums, p.Number)
 	}
 
 	if _, err := writeGPTTable(fp, gptTable); err != nil {
@@ -384,18 +381,36 @@ func addPartitionSet(d disko.Disk, pSet disko.PartitionSet) error {
 		return fmt.Errorf("failed to stat %s: %s", d.Path, err)
 	}
 
+	// Call addpart if this is a block device.
 	if info.Mode()&os.ModeDevice != 0 {
-		// Call partx if this is a block device.
-		for _, n := range pnums {
-			if err := runCommand("partx", "--add", fmt.Sprintf("%d", n), d.Path); err != nil {
+		// Close the filehandle and release the lock, then call udevSettle
+		// so that we can call addpart if needed.
+		fp.Close()
+
+		if err := udevSettle(); err != nil {
+			return err
+		}
+
+		for _, p := range pSet {
+			ppath := getPartPathForKname(d.Name, p.Number)
+			if exists, err := blockDeviceExists(ppath); err != nil {
+				return fmt.Errorf("failed to stat %s part %d (%s): %s",
+					d.Name, p.Number, getPartPathForKname(d.Name, p.Number), err)
+			} else if exists {
+				continue
+			}
+
+			// for the addpart interface to the kernel, units are always 512.
+			if err := runCommand("addpart", d.Path,
+				fmt.Sprintf("%d", p.Number),
+				fmt.Sprintf("%d", p.Start/sectorSize512),
+				fmt.Sprintf("%d", p.Size()/sectorSize512)); err != nil {
 				return err
 			}
 		}
 	}
 
-	// close the file handle, releasing the lock before calling udevSettle
-	// https://systemd.io/BLOCK_DEVICE_LOCKING/
-	return fp.Close()
+	return nil
 }
 
 func deletePartitions(d disko.Disk, pNums []uint) error {

--- a/linux/util.go
+++ b/linux/util.go
@@ -99,8 +99,22 @@ func cmdError(args []string, out []byte, err []byte, rc int) error {
 		return nil
 	}
 
-	return fmt.Errorf(
-		"command failed [%d]:\n cmd: %v\n out:%s\n err: %s",
+	return errors.New(cmdString(args, out, err, rc))
+}
+
+func cmdString(args []string, out []byte, err []byte, rc int) string {
+	tlen := len(err)
+	if tlen == 0 || err[tlen-1] != '\n' {
+		err = append(err, '\n')
+	}
+
+	tlen = len(out)
+	if tlen == 0 || out[tlen-1] != '\n' {
+		out = append(out, '\n')
+	}
+
+	return fmt.Sprintf(
+		"command returned %d:\n cmd: %v\n out: %s err: %s",
 		rc, args, out, err)
 }
 


### PR DESCRIPTION
Smaller changes here, in general order of notability:

 * use addpart instead of 'partx --add' and before doing so,
   close the device and settle.  This really should result in
   more reliable 'add'.

 * deletePartitions - use 'delpart' rather than 'partx --delete'.
   also, only call if needed (if the block device does not exist
   then do not bother calling delpart)

 * 'demo disk show' output more information.

 * internal change for formating of an error from a 'runCommand'.

The big thing here is the addition of 'demo misc updown' which just allows tests of create/delete.  An example:

    # ./demo misc updown /dev/sdf 
    numruns=1 partition=true createpv=true lvm=true
    [ #       Start       Last       Size Name            ]
    [ 1       3 MiB    253 MiB    250 MiB esp             ]
    [ 2     253 MiB   1277 MiB   1024 MiB atx-boot        ]
    [ 3    1277 MiB  29695 MiB  28418 MiB atx-core        ]
    [ 4   29695 MiB  30719 MiB   1024 MiB atx-reserved    ]
    [ 5   30719 MiB  31743 MiB   1024 MiB testme          ]
    [ -   31743 MiB 228936 MiB 197193 MiB <free>          ]

    [0] starting /dev/sdf 6
    [0] created partition 6
    [0] created PV /dev/sdf6: bkPTfJ-rJhk-rC73-cYj0-Tcfn-qaxz-6oDa65
    [0] created VG myvg0
    [0] created LV myvg0/mylv0 (100)
    [0] deleted PV /dev/sdf6
    [0] deleted partition /dev/sdf6

That created a 200MiB partition on /dev/sdf, then added it as a pv,
and then a vg on that pv, and an lv.  The took it all down.


