### PR TITLE
Fix/small sync and udev devlink priority

### DIFF
--- a/linux/disk.go
+++ b/linux/disk.go
@@ -330,7 +330,7 @@ func zeroStartEnd(fp io.WriteSeeker, start int64, last int64) error {
 
 // addPartitionSet - open the disk, add partitions.
 //     Caller's responsibility to udevSettle
-func addPartitionSet(d disko.Disk, pSet disko.PartitionSet) error {
+func addPartitionSet(d disko.Disk, pSet disko.PartitionSet) error { //nolint: funlen
 	fp, err := os.OpenFile(d.Path, os.O_RDWR, 0)
 	if err != nil {
 		return err
@@ -373,6 +373,10 @@ func addPartitionSet(d disko.Disk, pSet disko.PartitionSet) error {
 	}
 
 	if _, err := writeGPTTable(fp, gptTable); err != nil {
+		return err
+	}
+
+	if err := fp.Sync(); err != nil {
 		return err
 	}
 
@@ -442,6 +446,10 @@ func deletePartitions(d disko.Disk, pNums []uint) error {
 	}
 
 	if _, err := writeGPTTable(fp, gptTable); err != nil {
+		return err
+	}
+
+	if err := fp.Sync(); err != nil {
 		return err
 	}
 

--- a/linux/util.go
+++ b/linux/util.go
@@ -67,8 +67,10 @@ func parseUdevInfo(out []byte, info *disko.UdevInfo) error {
 			}
 
 			info.Properties[kv[0]] = strings.TrimSpace(s)
+		case 'L':
+			// a 'devlink priority'. skip for now.
 		default:
-			return fmt.Errorf("error parsing line: %v", line)
+			return fmt.Errorf("error parsing line: (%s)", line)
 		}
 	}
 


### PR DESCRIPTION
2 small fixes here:
 * Support reading devlink priority 'L:' from udevadm info output..
 * Sync() on the filehandle in addPartitionSet and delPartitions.

