### PR TITLE
Feature/add mbr support

### DIFF
--- a/linux/system.go
+++ b/linux/system.go
@@ -129,13 +129,15 @@ func (ls *linuxSystem) ScanDisk(devicePath string) (disko.Disk, error) {
 	}
 
 	disk.Size = size
-	parts, ssize, err := findPartitions(fh)
+	parts, tType, ssize, err := findPartitions(fh)
 
-	if err == ErrNoPartitionTable {
-		return disk, nil
+	if err != nil {
+		return disk, err
 	}
 
-	if ssize != disk.SectorSize {
+	disk.Table = tType
+
+	if tType == disko.GPT && ssize != disk.SectorSize {
 		if blockdev {
 			return disk, fmt.Errorf(
 				"disk %s has sector size %d and partition table sector size %d",

--- a/partid/partid.go
+++ b/partid/partid.go
@@ -1,5 +1,7 @@
 package partid
 
+import "fmt"
+
 // nolint:gochecknoglobals,lll
 var (
 	// Empty - Unused / Empty partition
@@ -76,4 +78,35 @@ var Text = map[[16]byte]string{ // nolint:gochecknoglobals
 	LinuxSrv:        "Linux /srv",
 	MBR:             "MBR",
 	BiosBoot:        "Bios Boot Partition",
+}
+
+// nolint: gomnd,gochecknoglobals
+var mapGPTToMBR = map[[16]byte]byte{
+	Empty:     0x00,
+	LinuxSwap: 0x82,
+	LinuxFS:   0x83,
+	LinuxLVM:  0x8E,
+	LUKS:      0xE8,
+}
+
+// PartTypeToMBR - Convert a GPT Type to its MBR equivalent
+func PartTypeToMBR(gptType [16]byte) (byte, error) {
+	if val, ok := mapGPTToMBR[gptType]; ok {
+		return val, nil
+	}
+
+	padded := true
+
+	for i := 0; i < 15; i++ {
+		if gptType[i] != 0 {
+			padded = false
+			break
+		}
+	}
+
+	if padded {
+		return gptType[15], nil
+	}
+
+	return 0, fmt.Errorf("unknown MBR type %v", gptType)
 }


### PR DESCRIPTION
Add limited support for MBR/DOS partition tables.

This adds code to write MBR partitions.  Ideally we only write these in
update cases.

It would be nice to have a 'convert' of some sort that would convert MBR
into GPT.  That would have to take into account the fact that we can't
yet read extended partitions.

Also, if a partition table is messed up then addPartitions will fail
because of the check call.  In that event, you'd need to disk.Wipe()
first.  Kind of annoying.  I think the right way to support writing
a new MBR would look a lot like newProtectiveMBR() that reads the
disk and just wipes the mbr section of the first sector, but leaves
the rest intact.

Also adds Table to Disk to store GPT or MBR or None.
