### PR TITLE
Add knowledge of nbd and loop devices as "attachments".

### DIFF
--- a/disk.go
+++ b/disk.go
@@ -94,11 +94,17 @@ const (
 
 	// IDE - indicates that the device is attached to IDE.
 	IDE
+
+	// NBD - a network block device (/dev/nbd0)
+	NBD
+
+	// LOOP - a loop device (/dev/loop0)
+	LOOP
 )
 
 func (t AttachmentType) String() string {
 	return []string{"UNKNOWN", "RAID", "SCSI", "ATA", "PCIE", "USB",
-		"VIRTIO", "IDE"}[t]
+		"VIRTIO", "IDE", "NBD", "LOOP"}[t]
 }
 
 // StringToAttachmentType - Convert a string to an AttachmentType
@@ -111,6 +117,8 @@ func StringToAttachmentType(atypeStr string) AttachmentType {
 		"PCIE":    PCIE,
 		"VIRTIO":  VIRTIO,
 		"IDE":     IDE,
+		"NBD":     NBD,
+		"LOOP":    LOOP,
 	}
 
 	if atype, ok := kmap[atypeStr]; ok {

--- a/disk_test.go
+++ b/disk_test.go
@@ -135,6 +135,8 @@ func TestAttachmentTypeString(t *testing.T) {
 		{disko.USB, "USB"},
 		{disko.VIRTIO, "VIRTIO"},
 		{disko.IDE, "IDE"},
+		{disko.NBD, "NBD"},
+		{disko.LOOP, "LOOP"},
 	} {
 		found := d.dtype.String()
 		if found != d.expected {

--- a/linux/disk.go
+++ b/linux/disk.go
@@ -100,6 +100,10 @@ func getAttachType(udInfo disko.UdevInfo) disko.AttachmentType {
 			attach = disko.VIRTIO
 		} else if strings.Contains(udInfo.SysPath, "/nvme/") {
 			attach = disko.PCIE
+		} else if strings.Contains(udInfo.SysPath, "/virtual/block/nbd") {
+			attach = disko.NBD
+		} else if strings.Contains(udInfo.SysPath, "/virtual/block/loop") {
+			attach = disko.LOOP
 		}
 	}
 


### PR DESCRIPTION
Now you will get NBD and LOOP show up as attachment types.

This doesn't fit perfectly as an "attachment", but it seems to
fit better than a TYPE.