### PR TITLE
Add properties to a disk to identify 'Ephemeral'.

### DIFF
--- a/disk.go
+++ b/disk.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 )
 
 // DiskType enumerates supported disk types.
@@ -262,6 +263,17 @@ func (p PropertySet) MarshalJSON() ([]byte, error) {
 	return json.Marshal(keys)
 }
 
+func (p PropertySet) String() string {
+	keys := []string{}
+	for k := range p {
+		keys = append(keys, string(k))
+	}
+
+	sort.Strings(keys)
+
+	return strings.Join(keys, ",")
+}
+
 // UnmarshalJSON - json unserialize
 func (p *PropertySet) UnmarshalJSON(b []byte) error {
 	s := map[string]bool{}
@@ -380,10 +392,11 @@ func (d Disk) String() string {
 	}
 
 	return fmt.Sprintf(
-		"%s (%s) Table=%s Size=%s NumParts=%d FreeSpace=%s/%d SectorSize=%d Attachment=%s Type=%s",
+		("%s (%s) Table=%s Size=%s NumParts=%d FreeSpace=%s/%d SectorSize=%d Attachment=%s Type=%s" +
+			" Props=%s"),
 		d.Name, d.Path, d.Table, mbsize(d.Size), len(d.Partitions),
 		mbsize(avail), len(fs), d.SectorSize,
-		d.Attachment, d.Type)
+		d.Attachment, d.Type, d.Properties.String())
 }
 
 // Details returns the disk details as a table formatted string.

--- a/linux/system.go
+++ b/linux/system.go
@@ -90,6 +90,10 @@ func getDiskProperties(d disko.UdevInfo) disko.PropertySet {
 		props[disko.Ephemeral] = true
 	}
 
+	if d.Properties["ID_MODEL"] == "Amazon EC2 NVMe Instance Storage" {
+		props[disko.Ephemeral] = true
+	}
+
 	return props
 }
 

--- a/linux/system.go
+++ b/linux/system.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"regexp"
 	"syscall"
 
 	"github.com/anuvu/disko"
@@ -21,6 +22,13 @@ func System() disko.System {
 		megaraid: megaraid.CachingStorCli(),
 	}
 }
+
+// example below, of an azure vmbus disk that is ephemeral.
+// matching intent of /lib/udev/rules.d/66-azure-ephemeral.rules
+// /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A03:00/device:07/VMBUS:01/00000000-0001-8899-0000-000000000000/
+//      host1/target1:0:1/1:0:1:0/block/sdb
+// nolint: gochecknoglobals
+var vmbusSyspathEphemeral = regexp.MustCompile(`.*/VMBUS:\d\d/00000000-0001-\d{4}-\d{4}-\d{12}/host.*`)
 
 func (ls *linuxSystem) ScanAllDisks(filter disko.DiskFilter) (disko.DiskSet, error) {
 	var err error
@@ -75,6 +83,16 @@ func (ls *linuxSystem) ScanDisks(filter disko.DiskFilter,
 	return disks, nil
 }
 
+func getDiskProperties(d disko.UdevInfo) disko.PropertySet {
+	props := disko.PropertySet{}
+
+	if vmbusSyspathEphemeral.MatchString(d.SysPath) {
+		props[disko.Ephemeral] = true
+	}
+
+	return props
+}
+
 func (ls *linuxSystem) ScanDisk(devicePath string) (disko.Disk, error) {
 	var err error
 	var blockdev = true
@@ -108,6 +126,8 @@ func (ls *linuxSystem) ScanDisk(devicePath string) (disko.Disk, error) {
 		attachType = disko.RAID
 	}
 
+	properties := getDiskProperties(udInfo)
+
 	disk := disko.Disk{
 		Name:       name,
 		Path:       devicePath,
@@ -115,6 +135,7 @@ func (ls *linuxSystem) ScanDisk(devicePath string) (disko.Disk, error) {
 		UdevInfo:   udInfo,
 		Type:       diskType,
 		Attachment: attachType,
+		Properties: properties,
 	}
 
 	fh, err := os.Open(devicePath)

--- a/linux/system_test.go
+++ b/linux/system_test.go
@@ -1,0 +1,73 @@
+package linux
+
+import (
+	"testing"
+
+	"github.com/anuvu/disko"
+)
+
+func TestGetDiskProperties(t *testing.T) {
+	azureSys := ("/devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A03:00/device:07/VMBUS:01" +
+		"/00000000-0001-8899-0000-000000000000/host1/target1:0:1/1:0:1:0/block/sdb")
+	scsiSys := "/devices/pci0000:00/0000:00:02.2/0000:05:00.0/host0/target0:0:8/0:0:8:0/block/sda"
+
+	tables := []struct {
+		info     disko.UdevInfo
+		expected disko.PropertySet
+	}{
+		{
+			disko.UdevInfo{
+				Name:     "sda",
+				SysPath:  scsiSys,
+				Symlinks: []string{},
+				Properties: map[string]string{
+					"ID_MODEL":    "SPCC M.2 PCIe SSD",
+					"ID_REVISION": "ECFM22.6"}},
+			disko.PropertySet{disko.Ephemeral: false}},
+		{
+			disko.UdevInfo{
+				Name:     "sdb",
+				SysPath:  azureSys,
+				Symlinks: []string{},
+				Properties: map[string]string{
+					"ID_MODEL":    "SPCC M.2 PCIe SSD",
+					"ID_REVISION": "ECFM22.6"}},
+			disko.PropertySet{disko.Ephemeral: true}},
+		{
+			disko.UdevInfo{
+				Name:     "sdb",
+				SysPath:  azureSys,
+				Symlinks: []string{},
+				Properties: map[string]string{
+					"DM_MULTIPATH_DEVICE_PATH": "0",
+					"ID_SERIAL_SHORT":          "AWS628703BD8E5BEB551",
+					"ID_WWN":                   "nvme.1d0f-4157...4616e63652053746f72616765-00000001",
+					"ID_MODEL":                 "Amazon EC2 NVMe Instance Storage",
+					"ID_REVISION":              "0",
+					"ID_SERIAL":                "Amazon EC2 NVMe Instance Storage_AWS628703BD8E5BEB551"}},
+
+			disko.PropertySet{disko.Ephemeral: true}},
+	}
+
+	for _, table := range tables {
+		found := getDiskProperties(table.info)
+		bad := []disko.Property{}
+
+		for k, v := range table.expected {
+			if found[k] != v {
+				bad = append(bad, k)
+			}
+		}
+
+		for k, v := range found {
+			if table.expected[k] != v {
+				bad = append(bad, k)
+			}
+		}
+
+		if len(bad) != 0 {
+			t.Errorf("getDiskProperties(%v) returned '%v'. expected '%v'",
+				table.info, found, table.expected)
+		}
+	}
+}


### PR DESCRIPTION
Cloud systems often have 'ephemeral' devices, which are backed by disks
in the local system.  These are generally faster or cheaper but less
reliable than other disks.

This adds a Disks.Properties{} that has a list of properties.
The only property at this point is Ephemeral.