### PR TITLE
Show virt-id in demo output if 'name' is empty.

### DIFF
--- a/demo/megaraid.go
+++ b/demo/megaraid.go
@@ -55,7 +55,12 @@ func megaraidDiskSummary(c *cli.Context) error {
 			stype = "SSD"
 		}
 
-		data = append(data, []string{vd.Path, vd.RaidName, stype, vd.Raw["State"]})
+		name := vd.RaidName
+		if vd.RaidName == "" {
+			name = fmt.Sprintf("virtid-%d", vd.ID)
+		}
+
+		data = append(data, []string{vd.Path, name, stype, vd.Raw["State"]})
 	}
 
 	for _, d := range ctrl.Drives {


### PR DESCRIPTION
The 'name' field of a virtual drive may be empty.  If that is the
case, show 'virtid-<num>' in output of 'megaraid disk-summary'.

Before:

    $ ./demo megaraid disk-summary
    Path     | Name | Type | State |
    /dev/sda |      | HDD  | Optl  |

After:

    $ ./demo megaraid disk-summary
    Path     | Name     | Type | State |
    /dev/sda | virtid-0 | HDD  | Optl  |
