### PR TITLE
Support failure if integration tests cannot run.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Test
       run: |
-        sudo go test -v -race -covermode=atomic -coverprofile coverage.txt ./...
+        sudo DISKO_INTEGRATION=run go test -v -race -covermode=atomic -coverprofile coverage.txt ./...
 
     - name: Upload Coverage report to CodeCov
       if: success()

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test:
 	go tool cover -html=coverage.txt -o coverage.html
 
 test-all:
-	$(ENV_ROOT) "GOCACHE=$$(go env GOCACHE)" "GOENV=$$(go env GOENV)" go test -v -coverprofile=coverage-all.txt ./...
+	$(ENV_ROOT) DISKO_INTEGRATION=$${DISKO_INTEGRATION:-run} "GOCACHE=$$(go env GOCACHE)" "GOENV=$$(go env GOENV)" go test -v -coverprofile=coverage-all.txt -count=1 ./...
 	go tool cover -html=coverage-all.txt -o coverage-all.html
 
 debug:

--- a/linux/root_test.go
+++ b/linux/root_test.go
@@ -59,7 +59,7 @@ func singlePartDisk(filePath string) (func() error, disko.Disk, error) {
 }
 
 func TestRootPartition(t *testing.T) {
-	skipIfNoLoop(t)
+	iSkipOrFail(t, isRoot, canUseLoop)
 	var loopDev string
 
 	ast := assert.New(t)
@@ -122,8 +122,7 @@ func TestRootPartition(t *testing.T) {
 }
 
 func TestRootLVMExtend(t *testing.T) {
-	skipIfNoLoop(t)
-	skipIfNoLVM(t)
+	iSkipOrFail(t, isRoot, canUseLoop, canUseLVM)
 
 	ast := assert.New(t)
 


### PR DESCRIPTION
Previously intergration tests would just Skip() if they did not have the
necessary tools to run.  That could lead to a situation where we don't
realize the tests are not running and happily trust c-i that was not
running integration tests.

Here, we let the behavior be controlled by DISKO_INTEGRATION environment
variable.
  * allow-skip (default): act as before (run if possible, or skip)
  * skip: always skip.
  * run: raise errors and fail if the conditions are not met.

Also, we set DISKO_INTEGRATION=run in c-i, so failures will fail.