### PR TITLE
2 small changes

### DIFF
--- a/linux/disk.go
+++ b/linux/disk.go
@@ -55,8 +55,7 @@ func getDiskType(udInfo disko.UdevInfo) (disko.DiskType, error) {
 	}
 
 	if isKvm() {
-		psuedoSsd := regexp.MustCompile("^ssd[0-9-]")
-		if psuedoSsd.MatchString(udInfo.Properties["ID_SERIAL"]) {
+		if strings.HasPrefix(udInfo.Properties["ID_SERIAL"], "ssd-") {
 			return disko.SSD, nil
 		}
 	}

--- a/linux/virt_test.go
+++ b/linux/virt_test.go
@@ -60,6 +60,6 @@ func TestVirtType(t *testing.T) {
 
 	if found != virtOracle {
 		t.Errorf("value not cached in systemVirtType. found %s expected %s\n",
-			string(found), string(virtOracle))
+			fmt.Sprint(found), fmt.Sprint(virtOracle))
 	}
 }


### PR DESCRIPTION
- use fmt.Sprint() rather than conversion of a fix bad use of string() 
   to convert an int (iota) to a string in a test case Errorf.
 - Simplify the check for identifing virtio ssds via hack of serial name.