### PR TITLE
Create VGs with metadata size of 128MiB.

### DIFF
--- a/linux/lvm.go
+++ b/linux/lvm.go
@@ -201,7 +201,11 @@ func (ls *linuxLVM) HasPV(name string) bool {
 }
 
 func (ls *linuxLVM) CreateVG(name string, pvs ...disko.PV) (disko.VG, error) {
-	cmd := []string{"lvm", "vgcreate", "--zero=y", name}
+	mdSize := 128 * disko.Mebibyte // nolint:gomnd
+	cmd := []string{"lvm", "vgcreate",
+		fmt.Sprintf("--metadatasize=%dB", mdSize),
+		"--zero=y", name}
+
 	for _, p := range pvs {
 		cmd = append(cmd, p.Path)
 	}


### PR DESCRIPTION
The default metadata size (vg_mda_size) is 4MiB.
We have had experience where this is limiting.  So just bump
the size to 128MiB.