### PR TITLE
Adjust code for less ignoring gomnd.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,6 @@ issues:
     # 1 is not a magic number. 3 is a magic number.
     - linters: ["gomnd"]
       text: "Magic number: 1,"
-    # test files can have globals.
-    - linters: ["gochecknoglobals"]
+    # test files can have globals and magic numbers.
+    - linters: ["gochecknoglobals", "gomnd"]
       path: _test.go

--- a/demo/misc.go
+++ b/demo/misc.go
@@ -76,7 +76,7 @@ func pathExists(fpath string) bool {
 }
 
 func findPartInfo(diskPath string) (disko.Partition, error) {
-	const mysize = 200 * disko.Mebibyte //nolint: gomnd
+	const mysize = 200 * disko.Mebibyte
 	var err error
 
 	mysys := linux.System()
@@ -142,7 +142,7 @@ func miscUpDown(c *cli.Context) error {
 	var vg disko.VG
 	var lv disko.LV
 
-	var createMiB, extendMiB uint64 = 100, 48 //nolint: gomnd
+	var createMiB, extendMiB uint64 = 100, 48
 
 	if fname == "" {
 		return fmt.Errorf("must provide disk/file to partition")

--- a/disk_test.go
+++ b/disk_test.go
@@ -47,29 +47,29 @@ func TestPartitionSize(t *testing.T) {
 
 func TestDiskString(t *testing.T) {
 	mib := disko.Mebibyte
-	gb := uint64(1000 * 1000 * 1000) // nolint: gomnd
+	gb := uint64(1000 * 1000 * 1000)
 
 	d := disko.Disk{
 		Name:       "sde",
 		Path:       "/dev/sde",
 		Size:       gb,
-		SectorSize: 512, //nolint: gomnd
+		SectorSize: 512,
 		Type:       disko.HDD,
 		Attachment: disko.ATA,
 		Partitions: disko.PartitionSet{
-			1: {Start: 3 * mib, Last: 253*mib - 1, Number: 1},   //nolint: gomnd
-			3: {Start: 500 * mib, Last: 600*mib - 1, Number: 3}, //nolint: gomnd
+			1: {Start: 3 * mib, Last: 253*mib - 1, Number: 1},
+			3: {Start: 500 * mib, Last: 600*mib - 1, Number: 3},
 		},
 		UdevInfo: disko.UdevInfo{},
 	}
 	found := " " + d.String() + " "
 
 	// disk size 1gb = 953 MiB. 600 = (253-3) + (953-600)
-	expectedFree := 600 // nolint: gomnd
+	expectedFree := 600
 
 	for _, substr := range []string{
 		fmt.Sprintf("Size=%d", gb),
-		fmt.Sprintf("FreeSpace=%dMiB/2", expectedFree), //nolint: gomnd
+		fmt.Sprintf("FreeSpace=%dMiB/2", expectedFree),
 		fmt.Sprintf("NumParts=%d", len(d.Partitions))} {
 		if !strings.Contains(found, " "+substr+" ") {
 			t.Errorf("%s: missing expected substring ' %s '", found, substr)
@@ -83,11 +83,11 @@ func TestDiskDetails(t *testing.T) {
 		Name:       "sde",
 		Path:       "/dev/sde",
 		Size:       mib * mib,
-		SectorSize: 512, //nolint: gomnd
+		SectorSize: 512,
 		Type:       disko.HDD,
 		Attachment: disko.ATA,
 		Partitions: disko.PartitionSet{
-			1: {Start: 3 * mib, Last: 253*mib - 1, Number: 1}, //nolint: gomnd
+			1: {Start: 3 * mib, Last: 253*mib - 1, Number: 1},
 		},
 		UdevInfo: disko.UdevInfo{},
 	}
@@ -152,7 +152,7 @@ func TestPartitionSerializeJson(t *testing.T) {
 	myIDStr := "01234567-89AB-CDEF-0123-456789ABCDEF"
 	myID, _ := disko.StringToGUID(myIDStr)
 	p := disko.Partition{
-		Start:  3 * disko.Mebibyte, //nolint:gomnd
+		Start:  3 * disko.Mebibyte,
 		Last:   253*disko.Mebibyte - 1,
 		ID:     myID,
 		Type:   partid.EFI,
@@ -198,8 +198,8 @@ func TestPartitionUnserializeJson(t *testing.T) {
 	}
 
 	expected := disko.Partition{
-		Start:  3 * disko.Mebibyte,     // nolint:gomnd
-		Last:   253*disko.Mebibyte - 1, // nolint:gomnd
+		Start:  3 * disko.Mebibyte,
+		Last:   253*disko.Mebibyte - 1,
 		ID:     myID,
 		Type:   partid.EFI,
 		Name:   "my system part",
@@ -217,8 +217,8 @@ func TestDiskSerializeJson(t *testing.T) {
 	d := disko.Disk{
 		Name:       "sda",
 		Path:       "/dev/sda",
-		Size:       500 * disko.Mebibyte, //nolint:gomnd
-		SectorSize: 512,                  //nolint:gomnd
+		Size:       500 * disko.Mebibyte,
+		SectorSize: 512,
 		Type:       disko.HDD,
 		Attachment: disko.ATA,
 	}
@@ -247,8 +247,8 @@ func TestDiskUnserializeJson(t *testing.T) {
 	expected := disko.Disk{
 		Name:       "sda",
 		Path:       "/dev/sda",
-		Size:       500 * disko.Mebibyte, //nolint:gomnd
-		SectorSize: 512,                  //nolint:gomnd
+		Size:       500 * disko.Mebibyte,
+		SectorSize: 512,
 		Type:       disko.HDD,
 		Attachment: disko.ATA,
 	}

--- a/linux/disk_test.go
+++ b/linux/disk_test.go
@@ -169,7 +169,7 @@ func TestMyPartition(t *testing.T) {
 	defer os.RemoveAll(tmpd)
 
 	fpath := path.Join(tmpd, "mydisk")
-	fsize := uint64(200 * 1024 * 1024) // nolint:gomnd
+	fsize := uint64(200 * 1024 * 1024)
 
 	if err := ioutil.WriteFile(fpath, []byte{}, 0644); err != nil {
 		t.Fatalf("Failed to write to a temp file: %s", err)
@@ -243,7 +243,7 @@ func TestMyPartitionMBR(t *testing.T) {
 	defer os.RemoveAll(tmpd)
 
 	fpath := path.Join(tmpd, "mydisk")
-	fsize := uint64(200 * 1024 * 1024) // nolint:gomnd
+	fsize := uint64(200 * 1024 * 1024)
 
 	if err := ioutil.WriteFile(fpath, []byte{}, 0644); err != nil {
 		t.Fatalf("Failed to write to a temp file: %s", err)
@@ -308,11 +308,11 @@ func TestWipeDisk(t *testing.T) {
 		t.Fatalf("Failed to create tempdir: %s", err)
 	}
 
-	mib := uint64(1024 * 1024) // nolint: gomnd
+	mib := uint64(1024 * 1024)
 
 	defer os.RemoveAll(tmpd)
 
-	disk, err := genTempGptDisk(tmpd, 50*mib) // nolint:gomnd
+	disk, err := genTempGptDisk(tmpd, 50*mib)
 	if err != nil {
 		t.Fatalf("Creation of temp disk failed: %s", err)
 	}
@@ -402,7 +402,7 @@ func TestDeletePartition(t *testing.T) {
 
 	defer os.RemoveAll(tmpd)
 
-	disk, err := genTempGptDisk(tmpd, 200*1024*1024) // nolint:gomnd
+	disk, err := genTempGptDisk(tmpd, 200*1024*1024)
 	if err != nil {
 		t.Fatalf("Creation of temp disk failed: %s", err)
 	}
@@ -445,7 +445,7 @@ func TestBadPartition(t *testing.T) {
 	defer os.RemoveAll(tmpd)
 
 	fpath := path.Join(tmpd, "mydisk")
-	fsize := uint64(200 * 1024 * 1024) // nolint:gomnd
+	fsize := uint64(200 * 1024 * 1024)
 
 	if err := ioutil.WriteFile(fpath, []byte{}, 0644); err != nil {
 		t.Fatalf("Failed to write to a temp file: %s", err)
@@ -466,7 +466,7 @@ func TestBadPartition(t *testing.T) {
 	myGUID := disko.GenGUID()
 
 	part := disko.Partition{
-		Start:  1024, // nolint:gomnd
+		Start:  1024,
 		Last:   fs[0].Last,
 		Type:   partid.LinuxLVM,
 		Name:   "mytest partition",

--- a/linux/lvm.go
+++ b/linux/lvm.go
@@ -201,7 +201,7 @@ func (ls *linuxLVM) HasPV(name string) bool {
 }
 
 func (ls *linuxLVM) CreateVG(name string, pvs ...disko.PV) (disko.VG, error) {
-	mdSize := 128 * disko.Mebibyte // nolint:gomnd
+	const mdSize = 128 * disko.Mebibyte
 	cmd := []string{"lvm", "vgcreate",
 		fmt.Sprintf("--metadatasize=%dB", mdSize),
 		"--zero=y", name}

--- a/linux/root_helpers_test.go
+++ b/linux/root_helpers_test.go
@@ -132,9 +132,9 @@ func waitForFileSize(devPath string) error {
 	defer fp.Close()
 
 	diskLen := int64(0)
-	napLen := time.Millisecond * 10 //nolint: gomnd
+	napLen := time.Millisecond * 10
 	startTime := time.Now()
-	endTime := startTime.Add(30 * time.Second) // nolint: gomnd
+	endTime := startTime.Add(30 * time.Second)
 
 	for {
 		if diskLen, err = fp.Seek(0, io.SeekEnd); err != nil {

--- a/linux/root_test.go
+++ b/linux/root_test.go
@@ -1,6 +1,6 @@
 // +build linux,!skipIntegration
 
-// nolint:errcheck,gomnd,funlen
+// nolint:errcheck,funlen
 package linux_test
 
 import (

--- a/linux/util_test.go
+++ b/linux/util_test.go
@@ -134,24 +134,24 @@ func TestRunCommand(t *testing.T) {
 
 func TestCeilingUp(t *testing.T) {
 	assert := assert.New(t)
-	assert.Equal(uint64(100), Ceiling(98, 4)) //nolint: gomnd
+	assert.Equal(uint64(100), Ceiling(98, 4))
 }
 
 func TestCeilingEven(t *testing.T) {
 	assert := assert.New(t)
-	assert.Equal(uint64(100), Ceiling(100, 4)) //nolint: gomnd
-	assert.Equal(uint64(97), Ceiling(97, 1))   //nolint: gomnd
+	assert.Equal(uint64(100), Ceiling(100, 4))
+	assert.Equal(uint64(97), Ceiling(97, 1))
 }
 
 func TestFloorDown(t *testing.T) {
 	assert := assert.New(t)
-	assert.Equal(uint64(96), Floor(98, 4)) //nolint: gomnd
+	assert.Equal(uint64(96), Floor(98, 4))
 }
 
 func TestFloorEven(t *testing.T) {
 	assert := assert.New(t)
-	assert.Equal(uint64(100), Floor(100, 4)) //nolint: gomnd
-	assert.Equal(uint64(97), Floor(97, 1))   //nolint: gomnd
+	assert.Equal(uint64(100), Floor(100, 4))
+	assert.Equal(uint64(97), Floor(97, 1))
 }
 
 func TestGetFileSize(t *testing.T) {

--- a/megaraid/storcli.go
+++ b/megaraid/storcli.go
@@ -192,14 +192,15 @@ func loadSections(cmdOut string) []scResultSection {
 
 func parseKeyValData(lines []string) map[string]string {
 	data := map[string]string{}
+	const tokNum2 = 2
 
 	for _, line := range lines {
 		if line == "" {
 			continue
 		}
 
-		toks := strings.SplitN(line, " = ", 2)
-		if len(toks) != 2 { // nolint:gomnd
+		toks := strings.SplitN(line, " = ", tokNum2)
+		if len(toks) != tokNum2 {
 			continue
 		}
 
@@ -380,6 +381,7 @@ func parseCxDallShow(cmdOut string) (VirtDriveSet, DriveSet, error) {
 func parseVirtProperties(cmdOut string) (map[int](map[string]string), error) {
 	var vID int
 	var err error
+	const tokNum2 = 2
 
 	nameMatch := regexp.MustCompile("^VD([0-9]+) Properties$")
 	vdmap := map[int](map[string]string){}
@@ -403,7 +405,7 @@ func parseVirtProperties(cmdOut string) (map[int](map[string]string), error) {
 			// Extract the VirtDrive Number from the Name (VD0 Properties)
 			toks := nameMatch.FindStringSubmatch(sect.Name)
 
-			if len(toks) != 2 { // nolint: gomnd
+			if len(toks) != tokNum2 {
 				return vdmap, fmt.Errorf("failed parsing section '%s'", sect.Name)
 			}
 
@@ -468,6 +470,7 @@ func parseDriveGroupVal(val string) (int, error) {
 func pdDataToDrive(data map[string]string) (Drive, error) {
 	var err error
 	var dID, dg, eID, slot int
+	const tokNum2 = 2
 
 	if dID, err = parseIntOrDash(data["DID"]); err != nil {
 		return Drive{}, err
@@ -477,8 +480,8 @@ func pdDataToDrive(data map[string]string) (Drive, error) {
 		return Drive{}, err
 	}
 
-	toks := strings.SplitN(data["EID:Slt"], ":", 2)
-	if len(toks) != 2 { // nolint:gomnd
+	toks := strings.SplitN(data["EID:Slt"], ":", tokNum2)
+	if len(toks) != tokNum2 {
 		return Drive{},
 			fmt.Errorf(
 				"splitting EID:Slt data '%s' on ':'' returned %d fields, expected 2",
@@ -560,9 +563,11 @@ type cachingStorCli struct {
 
 // CachingStorCli - just a cache for a MegaRaid
 func CachingStorCli() MegaRaid {
+	const longTime = 5 * time.Minute
+
 	return &cachingStorCli{
 		mr:    &storCli{},
-		cache: cache.New(5*time.Minute, 5*time.Minute), //nolint: gomnd
+		cache: cache.New(longTime, longTime),
 	}
 }
 

--- a/megaraid/storcli_test.go
+++ b/megaraid/storcli_test.go
@@ -110,7 +110,6 @@ func TestParseCxDallShowNotConfigured(t *testing.T) {
 		t.Errorf("Expected %d pds found %d\n", exPlen, len(pds))
 	}
 
-	// nolint:gomnd
 	expected := DriveSet{
 		13: &Drive{ID: 13, EID: 62, Slot: 3, DriveGroup: -1,
 			MediaType: HDD, Model: "MZ6ER400HAGL/003", State: "UBUnsp"},
@@ -268,7 +267,6 @@ func TestNewController(t *testing.T) {
 }
 
 func TestJsonDriveGroupSet(t *testing.T) {
-	//nolint: gomnd
 	dgs := DriveGroupSet{
 		1: &DriveGroup{
 			ID: 1,

--- a/mockos/lvm_test.go
+++ b/mockos/lvm_test.go
@@ -143,7 +143,7 @@ func TestVG(t *testing.T) {
 	})
 }
 
-//nolint: gomnd,funlen
+//nolint: funlen
 func TestLV(t *testing.T) {
 	Convey("test lvm lvs", t, func() {
 		sys := mockos.System("testdata/model_sys.json")

--- a/mockos/system_test.go
+++ b/mockos/system_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-//nolint: funlen, gomnd
+//nolint: funlen
 func TestSystem(t *testing.T) {
 	myID, _ := disko.StringToGUID("01234567-89AB-CDEF-0123-456789ABCDEF")
 

--- a/partid/partid.go
+++ b/partid/partid.go
@@ -80,7 +80,7 @@ var Text = map[[16]byte]string{ // nolint:gochecknoglobals
 	BiosBoot:        "Bios Boot Partition",
 }
 
-// nolint: gomnd,gochecknoglobals
+// nolint: gochecknoglobals,gomnd
 var mapGPTToMBR = map[[16]byte]byte{
 	Empty:     0x00,
 	LinuxSwap: 0x82,


### PR DESCRIPTION
Disable the gomnd (magic number) linter on test files.
Adjust code to use consts in most cases where we were ignoring
the linter (// nolint:gomnd).