### PR TITLE
Add support for CreateLV with thin or thinpool.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,11 @@ jobs:
       run: |
         go mod download
 
+    - name: Install Deps
+      run: |
+        sudo apt-get update --quiet
+        sudo apt-get install --quiet --assume-yes --no-install-recommends lvm2 thin-provisioning-tools
+
     - name: build
       run: |
         make build

--- a/linux/lvm.go
+++ b/linux/lvm.go
@@ -171,7 +171,8 @@ func (ls *linuxLVM) CreatePV(name string) (disko.PV, error) {
 		return nilPV, err
 	}
 
-	err = runCommandSettled("lvm", "pvcreate", "--zero=y", path)
+	err = runCommandSettled("lvm", "pvcreate", "--zero=y",
+		fmt.Sprintf("--metadatasize=%dB", pvMetaDataSize), path)
 
 	if err != nil {
 		return nilPV, err


### PR DESCRIPTION
A few quirks that allow us to keep the same old CreateLV interface:
 * The caller of CreateLV has to know that when creating a THIN lv, they
   have to pass the VG name as <vgname>/<thinpoolName>.
 * For THINPOOL types, the name given is the name of the thin pool.
   We accept the defaults from lvm for tdata and tmeta pool names.
   (creation of MyThinPool will have hidden volumes created named
    mythinpool_tdata and mythinpool_tmeta).
 * The MetaData pool size (--poolmetadatasize=) is hard coded to
   1GiB and a spare pool is created (--poolmetadataspare=y).