### PR TITLE
Add System.CreatePartitions to add multiple partitions at once.

### DIFF
--- a/linux/root_test.go
+++ b/linux/root_test.go
@@ -99,12 +99,8 @@ func TestRootPartition(t *testing.T) {
 		Number: 3,
 	}
 
-	if err = lSys.CreatePartition(disk, part1); err != nil {
-		t.Fatalf("failed create partition %#v", part1)
-	}
-
-	if err = lSys.CreatePartition(disk, part3); err != nil {
-		t.Fatalf("failed create partition %#v", part3)
+	if err = lSys.CreatePartitions(disk, disko.PartitionSet{1: part1, 3: part3}); err != nil {
+		t.Fatalf("failed create partitions %s", err)
 	}
 
 	disk, err = lSys.ScanDisk(loopDev)
@@ -119,6 +115,28 @@ func TestRootPartition(t *testing.T) {
 	ast.Equal(part1, found1, "partition 1 differed")
 	ast.Equal(part3, found3, "partition 3 differed")
 	ast.Equal(uint64(100*MiB), disk.FreeSpaces()[0].Size(), "freespace gap wrong size")
+
+	// Now add a single partition
+	part2 := disko.Partition{
+		Start:  disk.FreeSpaces()[0].Start,
+		Last:   disk.FreeSpaces()[0].Last,
+		Type:   disko.PartType(partid.LinuxFS),
+		Name:   randStr(8),
+		Number: 2,
+	}
+
+	if err = lSys.CreatePartition(disk, part2); err != nil {
+		t.Fatalf("failed create partition %#v", part2)
+	}
+
+	disk, err = lSys.ScanDisk(loopDev)
+	if err != nil {
+		t.Errorf("Failed to scan loopDev %s", loopDev)
+	}
+
+	found2 := disk.Partitions[part2.Number]
+	ast.Equal(part2, found2, "partition 2 differed")
+	ast.Equal(uint64(100*MiB), found2.Size(), "partition 2 had wrong size")
 }
 
 func TestRootLVMExtend(t *testing.T) {

--- a/linux/system.go
+++ b/linux/system.go
@@ -185,6 +185,14 @@ func (ls *linuxSystem) CreatePartition(d disko.Disk, p disko.Partition) error {
 	return udevSettle()
 }
 
+func (ls *linuxSystem) CreatePartitions(d disko.Disk, pSet disko.PartitionSet) error {
+	if err := addPartitionSet(d, pSet); err != nil {
+		return err
+	}
+
+	return udevSettle()
+}
+
 func (ls *linuxSystem) DeletePartition(d disko.Disk, number uint) error {
 	if err := deletePartitions(d, []uint{number}); err != nil {
 		return err

--- a/linux/system_test.go
+++ b/linux/system_test.go
@@ -1,9 +1,15 @@
 package linux
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/anuvu/disko"
+	"github.com/anuvu/disko/partid"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetDiskProperties(t *testing.T) {
@@ -70,4 +76,88 @@ func TestGetDiskProperties(t *testing.T) {
 				table.info, found, table.expected)
 		}
 	}
+}
+
+func genEmptyDisk(tmpd string, fsize uint64) (disko.Disk, error) {
+	fpath := path.Join(tmpd, "mydisk")
+
+	disk := disko.Disk{
+		Name:       "mydisk",
+		Path:       fpath,
+		Size:       fsize,
+		SectorSize: sectorSize512,
+	}
+
+	if err := ioutil.WriteFile(fpath, []byte{}, 0644); err != nil {
+		return disk, fmt.Errorf("Failed to write to a temp file: %s", err)
+	}
+
+	if err := os.Truncate(fpath, int64(fsize)); err != nil {
+		return disk, fmt.Errorf("Failed create empty file: %s", err)
+	}
+
+	fs := disk.FreeSpaces()
+	if len(fs) != 1 {
+		return disk, fmt.Errorf("Expected 1 free space, found %d", fs)
+	}
+
+	return disk, nil
+}
+
+func TestCreatePartitions(t *testing.T) {
+	ast := assert.New(t)
+
+	tmpd, err := ioutil.TempDir("", "disko_test")
+	if err != nil {
+		t.Fatalf("Failed to create tempdir: %s", err)
+	}
+
+	defer os.RemoveAll(tmpd)
+
+	disk, err := genEmptyDisk(tmpd, 50*disko.Mebibyte)
+	if err != nil {
+		t.Fatalf("Creation of temp disk failed: %s", err)
+	}
+
+	part1 := disko.Partition{
+		Start:  4 * disko.Mebibyte,
+		Last:   20*disko.Mebibyte - 1,
+		Type:   partid.LinuxHome,
+		Name:   "mytest 1",
+		ID:     disko.GenGUID(),
+		Number: uint(1),
+	}
+
+	part2 := disko.Partition{
+		Start:  20 * disko.Mebibyte,
+		Last:   40*disko.Mebibyte - 1,
+		Type:   partid.LinuxFS,
+		Name:   "mytest 2",
+		ID:     disko.GenGUID(),
+		Number: uint(2),
+	}
+
+	pSet := disko.PartitionSet{1: part1, 2: part2}
+
+	sys := System()
+	if err := sys.CreatePartitions(disk, pSet); err != nil {
+		t.Errorf("CreatePartitions failed: %s", err)
+	}
+
+	fp, err := os.Open(disk.Path)
+	if err != nil {
+		t.Fatalf("Failed to open disk image %s: %s", disk.Path, err)
+	}
+
+	pSetFound, _, _, err := findPartitions(fp)
+	if err != nil {
+		t.Fatalf("Failed to findPartitions on %s: %s", disk.Path, err)
+	}
+
+	if len(pSetFound) != len(pSet) {
+		t.Errorf("Scanned found %d partitions, expected %d", len(pSetFound), len(pSet))
+	}
+
+	ast.Equal(part1, pSetFound[1])
+	ast.Equal(part2, pSetFound[2])
 }

--- a/mockos/system.go
+++ b/mockos/system.go
@@ -84,6 +84,16 @@ func (ms *mockSys) CreatePartition(d disko.Disk, p disko.Partition) error {
 	return fmt.Errorf("disk %s does not exist", d.Name)
 }
 
+func (ms *mockSys) CreatePartitions(d disko.Disk, pSet disko.PartitionSet) error {
+	for _, p := range pSet {
+		if err := ms.CreatePartition(d, p); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (ms *mockSys) DeletePartition(d disko.Disk, number uint) error {
 	if disk, ok := ms.Disks[d.Name]; ok {
 		if _, ok := disk.Partitions[number]; !ok {

--- a/system.go
+++ b/system.go
@@ -35,6 +35,9 @@ type System interface {
 	// partition number, type and disk offsets.
 	CreatePartition(Disk, Partition) error
 
+	// CreatePartitions creates multiple partitions on disk.
+	CreatePartitions(Disk, PartitionSet) error
+
 	// DeletePartition deletes the specified partition.
 	DeletePartition(Disk, uint) error
 


### PR DESCRIPTION
When first partitioning a disk, the caller is likely to want to
create more than one partition.  The addition of CreatePartitions
means that the caller does not have to loop over CreatePartition
in order to do so.

This reduces the calls to open(disk), flock(disk), and Settle.