### PR TITLE
modify: for mmcblk disk like Raspberry Pi

### DIFF
--- a/linux/disk.go
+++ b/linux/disk.go
@@ -220,7 +220,7 @@ func findPartitions(fp io.ReadSeeker) (disko.PartitionSet, disko.TableType, uint
 }
 
 func getDiskNames() ([]string, error) {
-	realDiskKnameRegex := regexp.MustCompile("^((s|v|xv|h)d[a-z]|nvme[0-9]n[0-9]+)$")
+	realDiskKnameRegex := regexp.MustCompile("^((s|v|xv|h)d[a-z]|nvme[0-9]n[0-9]|mmcblk[0-9]+)$")
 	disks := []string{}
 
 	files, err := ioutil.ReadDir("/sys/block")


### PR DESCRIPTION
for mmcblk disk like Raspberry Pi can use.
root@ubuntu:/tmp# ls -l /sys/block/|grep mm
lrwxrwxrwx 1 root root 0 Mar  3 13:56 mmcblk0 -> ../devices/platform/soc/3f202000.mmc/mmc_host/mmc0/mmc0:59b4/block/mmcblk0
