### PR TITLE
Add Unsupported error for cases when storcli returns Un-supported.

### DIFF
--- a/linux/system.go
+++ b/linux/system.go
@@ -221,7 +221,8 @@ func (ls *linuxSystem) getDiskType(path string, udInfo disko.UdevInfo) (disko.Di
 				return disko.HDD, nil
 			}
 		}
-	} else if err != megaraid.ErrNoStorcli && err != megaraid.ErrNoController {
+	} else if err != megaraid.ErrNoStorcli && err != megaraid.ErrNoController &&
+		err != megaraid.ErrUnsupported {
 		return disko.HDD, err
 	}
 

--- a/megaraid/megaraid.go
+++ b/megaraid/megaraid.go
@@ -136,5 +136,8 @@ type MegaRaid interface {
 // ErrNoController - Error reported by Query if no controller is found.
 var ErrNoController = errors.New("megaraid Controller not found")
 
+// ErrUnsupported - Error reported by Query if controller is not supported.
+var ErrUnsupported = errors.New("megaraid Controller unsupported")
+
 // ErrNoStorcli - Error reported by Query if no storcli binary in PATH
 var ErrNoStorcli = errors.New("no 'storcli' command in PATH")

--- a/megaraid/storcli_test.go
+++ b/megaraid/storcli_test.go
@@ -136,6 +136,13 @@ func TestParseCxDallNoController(t *testing.T) {
 	}
 }
 
+func TestParseCxDallUnsupportedController(t *testing.T) {
+	_, _, err := parseCxDallShow(dallUnsupported)
+	if err != ErrUnsupported {
+		t.Fatalf("storcli /c0/dall dallUnsupported expected ErrUnsupported found: %s", err)
+	}
+}
+
 func TestForeignDriveDall(t *testing.T) {
 	_, drives, err := parseCxDallShow(foreignDallBlob)
 
@@ -215,6 +222,13 @@ func TestParseVirtPropertiesNoController(t *testing.T) {
 	if err != ErrNoController {
 		t.Fatalf("storcli /c0/vall vallNoController expected ErrNoController found: %s",
 			err)
+	}
+}
+
+func TestParseVirtPropertiesUnsupported(t *testing.T) {
+	_, _, err := parseCxDallShow(vallUnsupported)
+	if err != ErrUnsupported {
+		t.Fatalf("storcli /c0/vall vallUnsupported expected ErrUnsupported found: %s", err)
 	}
 }
 
@@ -867,3 +881,16 @@ Description = Controller 0 not found
 
 // storcli /c0/dall show all
 var dallNoController = vallNoController
+
+// storcli /c0/vall show all
+// https://github.com/anuvu/disko/issues/98
+var vallUnsupported = `
+CLI Version = 007.1507.0000.0000 Sep 18, 2020
+Operating system = Linux 5.10.19stock-1
+Controller = 0
+Status = Failure
+Description = Un-supported command
+`
+
+// storcli /c0/dall show all
+var dallUnsupported = vallUnsupported


### PR DESCRIPTION
The SAS3508 returns Un-supported when you ask it:

    storcli /c0/dall show all
    storcli /c0/vall show all

I'm not sure how we should query this card, but for the time being
just add a new error type of Unsupported.