### PR TITLE
For megaraid parsing, use /c0 show instead of /c0/dall show.

### DIFF
--- a/linux/system.go
+++ b/linux/system.go
@@ -221,7 +221,8 @@ func (ls *linuxSystem) getDiskType(path string, udInfo disko.UdevInfo) (disko.Di
 				return disko.HDD, nil
 			}
 		}
-	} else if err != megaraid.ErrNoStorcli && err != megaraid.ErrNoController {
+	} else if err != megaraid.ErrNoStorcli && err != megaraid.ErrNoController &&
+		err != megaraid.ErrUnsupported {
 		return disko.HDD, err
 	}
 

--- a/megaraid/linux.go
+++ b/megaraid/linux.go
@@ -40,6 +40,8 @@ func IsMegaRaidSysPath(syspath string) bool {
 func NameByDiskID(id int) (string, error) {
 	// given ID, we expect a single file in:
 	// <sysDriverMegaRaidSAS>/0000:05:00.0/host0/target0:0:<ID>/0:0:<ID>:0/block/
+	// Note: This does not work for some megaraid controllers such as SAS3508
+	// See https://github.com/anuvu/disko/issues/101
 	idStr := fmt.Sprintf("%d", id)
 	blkDir := sysDriverMegaRaidSAS + "/*/host*/target0:0:" + idStr + "/0:0:" + idStr + ":0/block/*"
 	matches, err := filepath.Glob(blkDir)

--- a/megaraid/megaraid.go
+++ b/megaraid/megaraid.go
@@ -136,5 +136,8 @@ type MegaRaid interface {
 // ErrNoController - Error reported by Query if no controller is found.
 var ErrNoController = errors.New("megaraid Controller not found")
 
+// ErrUnsupported - Error reported by Query if controller is not supported.
+var ErrUnsupported = errors.New("megaraid Controller unsupported")
+
 // ErrNoStorcli - Error reported by Query if no storcli binary in PATH
 var ErrNoStorcli = errors.New("no 'storcli' command in PATH")

--- a/megaraid/storcli.go
+++ b/megaraid/storcli.go
@@ -50,7 +50,7 @@ func (sc *storCli) Query(cID int) (Controller, error) {
 	var stdout, stderr []byte
 	var rc int
 
-	args := []string{fmt.Sprintf("/c%d/dall", cID), "show", "all", "nolog"}
+	args := []string{fmt.Sprintf("/c%d", cID), "show", "nolog"}
 
 	if stdout, stderr, rc = storcli(args...); rc != 0 {
 		var err error = ErrNoStorcli
@@ -81,13 +81,15 @@ func newController(cID int, cxDxOut string, cxVxOut string) (Controller, error) 
 		ID: cID,
 	}
 
-	vds, pds, err := parseCxDallShow(cxDxOut)
+	vds, pds, err := parseCxShow(cxDxOut)
 	if err != nil {
 		return ctrl, err
 	}
 
 	propMap, err := parseVirtProperties(cxVxOut)
-	if err != nil {
+	if err == ErrUnsupported {
+		propMap = map[int](map[string]string){}
+	} else if err != nil {
 		return ctrl, err
 	}
 
@@ -141,6 +143,8 @@ func loadSections(cmdOut string) []scResultSection {
 		{rsVirtDisk, regexp.MustCompile("^/c[0-9]+/v[0-9]+ :$")},
 		// PDs for VD 0
 		{rsPhysDisks, regexp.MustCompile("^PDs for VD [0-9]+ :$")},
+		// PD LIST (storcli /c0 show)
+		{rsPhysDisks, regexp.MustCompile("^PD LIST :$")},
 		// VD0 Properties (storcli /c0/vall show all)
 		{rsVirtProps, regexp.MustCompile("^.*VD[0-9]+ Properties :$")},
 		// VD LIST (storcli /c0/dall show all)
@@ -323,33 +327,48 @@ func cutTableLines(dataLines []string, cuts []int) []map[string]string {
 	return data
 }
 
-func parseCxDallShow(cmdOut string) (VirtDriveSet, DriveSet, error) {
+func isHeaderNotFound(header map[string]string) bool {
+	return header["Status"] == "Failure" &&
+		strings.Contains(header["Description"], "not found")
+}
+
+func isHeaderUnsupported(header map[string]string) bool {
+	return header["Status"] == "Failure" &&
+		strings.Contains(header["Description"], "Un-supported command")
+}
+
+func getHeaderError(header map[string]string) error {
+	if header["Status"] == "Success" {
+		return nil
+	}
+
+	if isHeaderNotFound(header) {
+		return ErrNoController
+	} else if isHeaderUnsupported(header) {
+		return ErrUnsupported
+	}
+
+	if _, err := strconv.Atoi(header["Controller"]); err != nil {
+		return fmt.Errorf("storcli controller in header not an int: %s", err)
+	}
+
+	return fmt.Errorf("storcli command returned status: %s", header["Status"])
+}
+
+// Parse the output of 'storcli /c0 show'
+func parseCxShow(cmdOut string) (VirtDriveSet, DriveSet, error) {
 	vds := VirtDriveSet{}
 	pds := DriveSet{}
-
-	var myHeader map[string]string
-	var err error
 
 	sections := loadSections(cmdOut)
 
 	for _, sect := range sections {
 		switch sect.Type {
 		case rsHeader:
-			myHeader = parseKeyValData(sect.Lines)
-
-			if myHeader["Status"] != "Success" {
-				if strings.Contains(myHeader["Description"], "not found") {
-					// Description = Controller 0 not found
-					return vds, pds, ErrNoController
-				}
-
-				return vds, pds,
-					fmt.Errorf("command failed. status: %s", myHeader["Status"])
+			if err := getHeaderError(parseKeyValData(sect.Lines)); err != nil {
+				return vds, pds, err
 			}
 
-			if _, err = strconv.Atoi(myHeader["Controller"]); err != nil {
-				return vds, pds, fmt.Errorf("controller in header not an int: %s", err)
-			}
 		case rsVdList:
 			data := parseTableData(sect.Lines)
 			for _, vdData := range data {
@@ -360,7 +379,7 @@ func parseCxDallShow(cmdOut string) (VirtDriveSet, DriveSet, error) {
 
 				vds[vd.ID] = &vd
 			}
-		case rsDgDriveList:
+		case rsPhysDisks:
 			data := parseTableData(sect.Lines)
 			for _, pdData := range data {
 				pd, err := pdDataToDrive(pdData)
@@ -391,15 +410,8 @@ func parseVirtProperties(cmdOut string) (map[int](map[string]string), error) {
 	for _, sect := range sections {
 		switch sect.Type {
 		case rsHeader:
-			myHeader := parseKeyValData(sect.Lines)
-
-			if myHeader["Status"] != "Success" {
-				if strings.Contains(myHeader["Description"], "not found") {
-					// Description = Controller 0 not found
-					return vdmap, ErrNoController
-				}
-
-				return vdmap, fmt.Errorf("command failed. status: %s", myHeader["Status"])
+			if err := getHeaderError(parseKeyValData(sect.Lines)); err != nil {
+				return vdmap, err
 			}
 		case rsVirtProps:
 			// Extract the VirtDrive Number from the Name (VD0 Properties)


### PR DESCRIPTION
For megaraid cards that do not support raid (true story), the
/c0/dall request will return Un-supported.  But you can still get the
same information from the 'storcli /c0 show'.

Fixes #98.