### PR TITLE
Fix error in wipeDisk preventing the wiping of partition ends.

### DIFF
--- a/linux/disk.go
+++ b/linux/disk.go
@@ -340,8 +340,8 @@ func wipeDisk(disk disko.Disk) error {
 	for _, p := range disk.Partitions {
 		// The point of this operation is to wipe.  Avoid out of range errors
 		// that could happen as part of a bad partition table.
-		end := disk.Size
-		if end > p.Last {
+		end := p.Last
+		if end > disk.Size {
 			end = disk.Size
 		}
 


### PR DESCRIPTION
The logic here was just wrong. It was attempting to avoid a
request to zeroStartEnd to write past the end of the disk, but
actually meant that it would always use the disk end.