### PR TITLE
Add a Read-Only property to indicate disks to which disko can't wipe

### DIFF
--- a/demo/disk.go
+++ b/demo/disk.go
@@ -100,15 +100,18 @@ func diskShow(c *cli.Context) error {
 }
 
 func getDiskSet(mysys disko.System, paths ...string) (disko.DiskSet, error) {
-	matchAll := func(d disko.Disk) bool {
+	matchAllSkipReadOnly := func(d disko.Disk) bool {
+		if _, ok := d.Properties[disko.ReadOnly]; ok == true {
+			return false
+		}
 		return true
 	}
 
 	if len(paths) == 0 || (len(paths) == 1 && paths[0] == "all") {
-		return mysys.ScanAllDisks(matchAll)
+		return mysys.ScanAllDisks(matchAllSkipReadOnly)
 	}
 
-	return mysys.ScanDisks(matchAll, paths...)
+	return mysys.ScanDisks(matchAllSkipReadOnly, paths...)
 }
 
 func diskWipe(c *cli.Context) error {

--- a/disk.go
+++ b/disk.go
@@ -240,6 +240,8 @@ type Property string
 const (
 	// Ephemeral - A cloud ephemeral disk.
 	Ephemeral Property = "EPHEMERAL"
+	// ReadOnly  - A disk that cannot be modified, writes fail
+	ReadOnly Property = "READ-ONLY"
 )
 
 // PropertySet - a group of properties of a disk

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/anuvu/disko
 go 1.13
 
 require (
+	github.com/Jeffail/gabs v1.4.0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/rekby/gpt v0.0.0-20200219180433-a930afbc6edc

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Jeffail/gabs v1.4.0 h1://5fYRRTq1edjfIrQGvdkcd22pkYUrHZ5YC/H2GJVAo=
+github.com/Jeffail/gabs v1.4.0/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/util.go
+++ b/util.go
@@ -2,6 +2,7 @@ package disko
 
 import (
 	"fmt"
+	"os"
 	"sort"
 )
 
@@ -60,4 +61,12 @@ func findRangeGaps(ranges uRanges, min, max uint64) uRanges {
 	}
 
 	return ret
+}
+
+func PathExists(d string) bool {
+	_, err := os.Stat(d)
+	if err != nil && os.IsNotExist(err) {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
On Linux, block devices which are not writable have the sysfs attribute
'ro' set to '1', otherwise '0'.  When scanning disks, check the 'ro'
sysfs attribute, and if '1' then set the READ-ONLY property on the
Disk object.  This can be used to not consider disks which are marked
read-only for wiping; the writes fail and the command aborts.