### PR TITLE
Add UpdatePartition and UpdatePartitions interface.

### DIFF
--- a/disk.go
+++ b/disk.go
@@ -542,6 +542,16 @@ func (p PartType) String() string {
 	return GUIDToString(GUID(p))
 }
 
+// StringToPartType - convert a string to a partition type.
+func StringToPartType(s string) (PartType, error) {
+	p, err := StringToGUID(s)
+	if err != nil {
+		return PartType{}, err
+	}
+
+	return PartType(p), nil
+}
+
 // FreeSpace indicates a free slot on the disk with a Start and Last offset,
 // where a partition can be created.
 type FreeSpace struct {

--- a/linux/system.go
+++ b/linux/system.go
@@ -200,6 +200,22 @@ func (ls *linuxSystem) DeletePartition(d disko.Disk, number uint) error {
 	return udevSettle()
 }
 
+func (ls *linuxSystem) UpdatePartition(d disko.Disk, p disko.Partition) error {
+	if err := updatePartitions(d, disko.PartitionSet{p.Number: p}); err != nil {
+		return err
+	}
+
+	return udevSettle()
+}
+
+func (ls *linuxSystem) UpdatePartitions(d disko.Disk, pSet disko.PartitionSet) error {
+	if err := updatePartitions(d, pSet); err != nil {
+		return err
+	}
+
+	return udevSettle()
+}
+
 func (ls *linuxSystem) Wipe(d disko.Disk) error {
 	if err := wipeDisk(d); err != nil {
 		return err

--- a/mockos/system.go
+++ b/mockos/system.go
@@ -94,6 +94,44 @@ func (ms *mockSys) CreatePartitions(d disko.Disk, pSet disko.PartitionSet) error
 	return nil
 }
 
+func (ms *mockSys) UpdatePartition(d disko.Disk, p disko.Partition) error {
+	cur, ok := d.Partitions[p.Number]
+
+	if !ok {
+		return fmt.Errorf("partition %d did not exist on disk %s", p.Number, d)
+	}
+
+	emptyGUID := disko.GUID{}
+	emptyType := disko.PartType{}
+	upd := cur
+
+	if p.Name != "" {
+		upd.Name = p.Name
+	}
+
+	if p.ID != emptyGUID {
+		upd.ID = p.ID
+	}
+
+	if p.Type != emptyType {
+		upd.Type = p.Type
+	}
+
+	d.Partitions[p.Number] = upd
+
+	return nil
+}
+
+func (ms *mockSys) UpdatePartitions(d disko.Disk, pSet disko.PartitionSet) error {
+	for _, p := range pSet {
+		if err := ms.UpdatePartition(d, p); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (ms *mockSys) DeletePartition(d disko.Disk, number uint) error {
 	if disk, ok := ms.Disks[d.Name]; ok {
 		if _, ok := disk.Partitions[number]; !ok {

--- a/system.go
+++ b/system.go
@@ -38,6 +38,12 @@ type System interface {
 	// CreatePartitions creates multiple partitions on disk.
 	CreatePartitions(Disk, PartitionSet) error
 
+	// UpdatePartition updates multiple existing partitions on a disk.
+	UpdatePartition(Disk, Partition) error
+
+	// UpdatePartitions updates multiple existing partitions on a disk.
+	UpdatePartitions(Disk, PartitionSet) error
+
 	// DeletePartition deletes the specified partition.
 	DeletePartition(Disk, uint) error
 


### PR DESCRIPTION
This allows caller to update the Name, ID, and GUID on a partition type.
Previously to accomplish this, caller would have to delete the partition
and add a new one with the updated info.

For now, the size of the partition is not updated.