### PR TITLE
golint cleanups and adjustments.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,6 @@ jobs:
         go-version: 1.13.x
     - name: Checkout code
       uses: actions/checkout@v1
-    - name: Install golangci-lint
-      run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.22.2
     - name: Run linters
       run: |
-        export PATH=$PATH:$(go env GOPATH)/bin   
-        golangci-lint run --enable-all ./...
+        make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,9 +6,7 @@ linters-settings:
     statements: 60
 
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  # you can see what is disabled with: golangci-lint linters
   enable:
     - bodyclose
     - deadcode

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,70 @@ linters-settings:
     lines: 80
     statements: 60
 
+linters:
+  # please, do not use `enable-all`: it's deprecated and will be removed soon.
+  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exhaustive
+    - exportloopref
+    - funlen
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - revive
+    - rowserrcheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+    - wsl
+
+  # don't enable:
+  # - asciicheck
+  # - gochecknoglobals
+  # - gocognit
+  # - godot
+  # - godox
+  # - goerr113
+  # - maligned
+  # - nestif
+  # - prealloc
+  # - testpackage
+  # - wsl
+  # - goimports
+
+# golangci.com configuration
+# https://github.com/golangci/golangci/wiki/Configuration
+service:
+  golangci-lint-version: 1.30.x # use the fixed version to not introduce new linters unexpectedly
+  prepare:
+    - echo "I wish I could be prepared. But, nothing to do here for the moment"
+
 issues:
   exclude-rules:
     - linters: ["gocritic"]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,7 +34,6 @@ linters:
     - nakedret
     - noctx
     - nolintlint
-    - revive
     - rowserrcheck
     - staticcheck
     - structcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,6 @@ linters:
     - gocritic
     - gocyclo
     - gofmt
-    - gomnd
     - goprintffuncname
     - gosec
     - gosimple
@@ -55,6 +54,7 @@ linters:
   # - godot
   # - godox
   # - goerr113
+  # - gomnd
   # - maligned
   # - nestif
   # - prealloc
@@ -73,9 +73,3 @@ issues:
   exclude-rules:
     - linters: ["gocritic"]
       text: "ifElseChain:"
-    # 1 is not a magic number. 3 is a magic number.
-    - linters: ["gomnd"]
-      text: "Magic number: 1,"
-    # test files can have globals and magic numbers.
-    - linters: ["gochecknoglobals", "gomnd"]
-      path: _test.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - exhaustive
     - exportloopref
     - funlen
+    - gochecknoglobals
     - gochecknoinits
     - goconst
     - gocritic
@@ -46,29 +47,10 @@ linters:
     - whitespace
     - wsl
 
-  # don't enable:
-  # - asciicheck
-  # - gochecknoglobals
-  # - gocognit
-  # - godot
-  # - godox
-  # - goerr113
-  # - gomnd
-  # - maligned
-  # - nestif
-  # - prealloc
-  # - testpackage
-  # - wsl
-  # - goimports
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.30.x # use the fixed version to not introduce new linters unexpectedly
-  prepare:
-    - echo "I wish I could be prepared. But, nothing to do here for the moment"
-
 issues:
   exclude-rules:
     - linters: ["gocritic"]
       text: "ifElseChain:"
+    # test files can have globals
+    - linters: ["gochecknoglobals"]
+      path: _test.go

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ gofmt: .gofmt
 lint: .lint
 
 .lint: $(ALL_GO_FILES)
-	golangci-lint run --enable-all
+	golangci-lint run
 	@touch $@
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ LDFLAGS := "${ldflags:+$ldflags }-X main.version=${ver}${suff}"
 BUILD_FLAGS := -ldflags "-X main.version=$(VERSION_FULL)"
 ENV_ROOT := $(shell [ "$$(id -u)" = "0" ] && echo env || echo sudo )
 
+GOLANGCI_VER = v1.43.0
+GOLANGCI = ./tools/golangci-lint-$(GOLANGCI_VER)
+
 CMDS := demo/demo ptimg/ptimg
 
 GO_FILES := $(wildcard *.go)
@@ -32,10 +35,18 @@ gofmt: .gofmt
 	o=$$(gofmt -l -w .) && [ -z "$$o" ] || { echo "gofmt made changes: $$o"; exit 1; }
 	@touch $@
 
+
+golangci-lint: $(GOLANGCI)
+
+$(GOLANGCI):
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
+		sh -s -- -b $(dir $@) $(GOLANGCI_VER) || { rm -f $(dir $@)/golangci-lint; exit 1; }
+	mv $(dir $@)/golangci-lint $@
+
 lint: .lint
 
-.lint: $(ALL_GO_FILES)
-	golangci-lint run
+.lint: $(ALL_GO_FILES) $(GOLANGCI) .golangci.yml
+	$(GOLANGCI) run ./...
 	@touch $@
 
 test:
@@ -59,4 +70,4 @@ debug:
 clean:
 	rm -f $(CMDS) coverage*.txt coverage*.html .lint .build
 
-.PHONY: debug check test test-all gofmt clean all lint build
+.PHONY: debug check test test-all gofmt clean all lint build golangci-lint

--- a/disk.go
+++ b/disk.go
@@ -375,7 +375,7 @@ func (d *Disk) FreeSpaces() []FreeSpace {
 }
 
 func (d Disk) String() string {
-	var avail uint64 = 0
+	var avail uint64
 
 	fs := d.FreeSpaces()
 
@@ -402,7 +402,7 @@ func (d Disk) String() string {
 // Details returns the disk details as a table formatted string.
 func (d Disk) Details() string {
 	fss := d.FreeSpaces()
-	var fsn int = 0
+	var fsn int
 
 	mbsize := func(n, o uint64) string {
 		if (n+o)%Mebibyte == 0 {

--- a/linux/disk.go
+++ b/linux/disk.go
@@ -183,7 +183,7 @@ func readMBRTable(fp io.ReadSeeker) (disko.PartitionSet, error) {
 	return parts, nil
 }
 
-func findPartitions(fp io.ReadSeeker) (disko.PartitionSet, disko.TableType, uint, error) { // nolint: unparam
+func findPartitions(fp io.ReadSeeker) (disko.PartitionSet, disko.TableType, uint, error) {
 	var err error
 	var ssize uint
 	var gptTable gpt.Table

--- a/linux/disk.go
+++ b/linux/disk.go
@@ -30,7 +30,6 @@ const (
 // ErrNoPartitionTable is returned if there is no partition table.
 var ErrNoPartitionTable = errors.New("no Partition Table Found")
 
-// nolint: gochecknoglobals
 var xenbusSysPathMatch = regexp.MustCompile(`/devices/vbd-\d+/block/`)
 
 // toGPTPartition - convert the Partition type into a gpt.Partition

--- a/linux/disk.go
+++ b/linux/disk.go
@@ -28,7 +28,7 @@ const (
 )
 
 // ErrNoPartitionTable is returned if there is no partition table.
-var ErrNoPartitionTable error = errors.New("no Partition Table Found")
+var ErrNoPartitionTable = errors.New("no Partition Table Found")
 
 // nolint: gochecknoglobals
 var xenbusSysPathMatch = regexp.MustCompile(`/devices/vbd-\d+/block/`)
@@ -271,7 +271,7 @@ func getSysPathForBlockDevicePath(dev string) (string, error) {
 	// Return the path in /sys/class/block/<device> for a given
 	// block device kname or path.
 	var syspath string
-	var sysdir string = "/sys/class/block"
+	var sysdir = "/sys/class/block"
 
 	if strings.Contains(dev, "/") {
 		// after symlink resolution, devpath = '/dev/sda' or '/dev/sdb1'

--- a/linux/disk_test.go
+++ b/linux/disk_test.go
@@ -128,7 +128,7 @@ func genTempGptDisk(tmpd string, fsize uint64) (disko.Disk, error) {
 		SectorSize: sectorSize512,
 	}
 
-	if err := ioutil.WriteFile(fpath, []byte{}, 0644); err != nil {
+	if err := ioutil.WriteFile(fpath, []byte{}, 0600); err != nil {
 		return disk, fmt.Errorf("Failed to write to a temp file: %s", err)
 	}
 
@@ -171,7 +171,7 @@ func TestMyPartition(t *testing.T) {
 	fpath := path.Join(tmpd, "mydisk")
 	fsize := uint64(200 * 1024 * 1024)
 
-	if err := ioutil.WriteFile(fpath, []byte{}, 0644); err != nil {
+	if err := ioutil.WriteFile(fpath, []byte{}, 0600); err != nil {
 		t.Fatalf("Failed to write to a temp file: %s", err)
 	}
 
@@ -245,7 +245,7 @@ func TestMyPartitionMBR(t *testing.T) {
 	fpath := path.Join(tmpd, "mydisk")
 	fsize := uint64(200 * 1024 * 1024)
 
-	if err := ioutil.WriteFile(fpath, []byte{}, 0644); err != nil {
+	if err := ioutil.WriteFile(fpath, []byte{}, 0600); err != nil {
 		t.Fatalf("Failed to write to a temp file: %s", err)
 	}
 
@@ -447,7 +447,7 @@ func TestBadPartition(t *testing.T) {
 	fpath := path.Join(tmpd, "mydisk")
 	fsize := uint64(200 * 1024 * 1024)
 
-	if err := ioutil.WriteFile(fpath, []byte{}, 0644); err != nil {
+	if err := ioutil.WriteFile(fpath, []byte{}, 0600); err != nil {
 		t.Fatalf("Failed to write to a temp file: %s", err)
 	}
 

--- a/linux/lvm.go
+++ b/linux/lvm.go
@@ -304,6 +304,8 @@ func (ls *linuxLVM) CreateLV(vgName string, name string, size uint64,
 	sizeB := fmt.Sprintf("%dB", size)
 	vglv := vgLv(vgName, name)
 
+	// Missing cases: LVTypeUnknown
+	//exhaustive:ignore
 	switch lvType {
 	case disko.THIN:
 		// When creating THIN LV, the VG must be <vgname>/<thinLVName>

--- a/linux/lvmdump.go
+++ b/linux/lvmdump.go
@@ -9,9 +9,7 @@ import (
 
 func readReportUint64(s string) uint64 {
 	// lvm --report-format=json --unit=B puts unit 'B' at end of all sizes.
-	if strings.HasSuffix(s, "B") {
-		s = s[:len(s)-1]
-	}
+	s = strings.TrimSuffix(s, "B")
 
 	num, err := strconv.ParseUint(s, 10, 64)
 	if err != nil {

--- a/linux/lvmdump_test.go
+++ b/linux/lvmdump_test.go
@@ -9,7 +9,7 @@ import (
 
 var size1 uint64 = 27514634240
 var size2 uint64 = 55029268480
-var size3 uint64 = size2 * 2
+var size3 = size2 * 2
 
 func asBS(b uint64) string {
 	return fmt.Sprintf("%dB", b)

--- a/linux/root_helpers_test.go
+++ b/linux/root_helpers_test.go
@@ -1,4 +1,3 @@
-// nolint:errcheck
 package linux_test
 
 import (

--- a/linux/root_helpers_test.go
+++ b/linux/root_helpers_test.go
@@ -3,11 +3,11 @@ package linux_test
 
 import (
 	"bytes"
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path"
@@ -179,6 +179,8 @@ func getTempFile(size int64) (cleaner, string) {
 	return cleaner{func() error { return os.Remove(name) }, "remove tempFile " + name}, name
 }
 
+// we don't need crypto/math random numbers to construct a random string
+//nolint:gosec
 func randStr(n int) string {
 	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 

--- a/linux/root_helpers_test.go
+++ b/linux/root_helpers_test.go
@@ -3,11 +3,11 @@ package linux_test
 
 import (
 	"bytes"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"os/exec"
 	"path"

--- a/linux/root_test.go
+++ b/linux/root_test.go
@@ -1,3 +1,4 @@
+//go:build linux && !skipIntegration
 // +build linux,!skipIntegration
 
 // nolint:errcheck,funlen

--- a/linux/system.go
+++ b/linux/system.go
@@ -27,7 +27,6 @@ func System() disko.System {
 // matching intent of /lib/udev/rules.d/66-azure-ephemeral.rules
 // /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A03:00/device:07/VMBUS:01/00000000-0001-8899-0000-000000000000/
 //      host1/target1:0:1/1:0:1:0/block/sdb
-// nolint: gochecknoglobals
 var vmbusSyspathEphemeral = regexp.MustCompile(`.*/VMBUS:\d\d/00000000-0001-\d{4}-\d{4}-\d{12}/host.*`)
 
 func (ls *linuxSystem) ScanAllDisks(filter disko.DiskFilter) (disko.DiskSet, error) {

--- a/linux/system_test.go
+++ b/linux/system_test.go
@@ -88,7 +88,7 @@ func genEmptyDisk(tmpd string, fsize uint64) (disko.Disk, error) {
 		SectorSize: sectorSize512,
 	}
 
-	if err := ioutil.WriteFile(fpath, []byte{}, 0644); err != nil {
+	if err := ioutil.WriteFile(fpath, []byte{}, 0600); err != nil {
 		return disk, fmt.Errorf("Failed to write to a temp file: %s", err)
 	}
 

--- a/linux/util_test.go
+++ b/linux/util_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//nolint: lll
 func TestParseUdevInfo(t *testing.T) {
 	data := []byte(`P: /devices/virtual/block/dm-0
 N: dm-0

--- a/linux/virt.go
+++ b/linux/virt.go
@@ -74,7 +74,7 @@ func getVirtTypeIface(sdv detector) virtType {
 	out, stderr, rc := sdv.detectVirt()
 
 	if rc == 0 || rc == 1 {
-		var strOut string = ""
+		var strOut string
 		if len(out) > 1 {
 			strOut = string(out[:len(out)-1])
 		}

--- a/megaraid/storcli.go
+++ b/megaraid/storcli.go
@@ -128,9 +128,9 @@ func newController(cID int, cxDxOut string, cxVxOut string) (Controller, error) 
 
 // loadSections - parse a storcli output into sections.
 func loadSections(cmdOut string) []scResultSection {
-	var header bool = false
+	var header = false
 	var curSect scResultSection
-	var last string = ""
+	var last string
 
 	equalLine := regexp.MustCompile("^[=]+$")
 	rSects := []scResultSection{}
@@ -363,6 +363,8 @@ func parseCxShow(cmdOut string) (VirtDriveSet, DriveSet, error) {
 	sections := loadSections(cmdOut)
 
 	for _, sect := range sections {
+		// Missing Cases: rsDgDriveList, rsUnknown, rsVirtDisk, rsVirtProps
+		//exhaustive:ignore
 		switch sect.Type {
 		case rsHeader:
 			if err := getHeaderError(parseKeyValData(sect.Lines)); err != nil {
@@ -408,6 +410,8 @@ func parseVirtProperties(cmdOut string) (map[int](map[string]string), error) {
 	sections := loadSections(cmdOut)
 
 	for _, sect := range sections {
+		// Missing cases: rsDgDriveList, rsPhysDisks, rsUnknown, rsVdList, rsVirtDisk
+		//exhaustive:ignore
 		switch sect.Type {
 		case rsHeader:
 			if err := getHeaderError(parseKeyValData(sect.Lines)); err != nil {

--- a/ptimg/main.go
+++ b/ptimg/main.go
@@ -31,6 +31,7 @@ first-lba: 2048
 
 1 : start=2048, size=1048576
 `
+const DefaultErrorCode = 127
 
 func getCommandErrorRCDefault(err error, rcError int) int {
 	if err == nil {
@@ -48,7 +49,7 @@ func getCommandErrorRCDefault(err error, rcError int) int {
 }
 
 func getCommandErrorRC(err error) int {
-	return getCommandErrorRCDefault(err, 127)
+	return getCommandErrorRCDefault(err, DefaultErrorCode)
 }
 
 func cmdError(args []string, out []byte, err []byte, rc int) error {
@@ -243,7 +244,7 @@ func connectDevice(fname string, imgFormat string) (func() error, string, error)
 	var cleanup = func() error { return nil }
 	var devPath string
 	var err error
-	var forceNBD bool = false
+	var forceNBD bool
 
 	val := os.Getenv("FORCE_NBD")
 	if val != "" {

--- a/ptimg/main.go
+++ b/ptimg/main.go
@@ -460,7 +460,6 @@ func createOrFindPartition(dSys disko.System, devPath string, ptname string, max
 	return ptNum, err
 }
 
-//nolint: funlen
 func handleMount(cpSrc string, exCmd []string, devPath string, subs map[string]string) error {
 	var tempDir, mountPoint string
 	var err error


### PR DESCRIPTION
This takes over the good work in @raharper 's https://github.com/anuvu/disko/pull/107 pull request.

I just added to it with some a 'make lint' target that downloads and uses the correct version of golint, so now a developer can easily just run 'make lint' and use the version that c-i will use.

