### PR TITLE
Feature/scandisk on file

### DIFF
--- a/disk.go
+++ b/disk.go
@@ -19,10 +19,13 @@ const (
 
 	// NVME - Non-volatile memory express
 	NVME
+
+	// TYPEFILE - A file on disk, not a block device.
+	TYPEFILE
 )
 
 func (t DiskType) String() string {
-	return []string{"HDD", "SSD", "NVME"}[t]
+	return []string{"HDD", "SSD", "NVME", "FILE"}[t]
 }
 
 // StringToDiskType - convert a string to a disk type.
@@ -31,6 +34,7 @@ func StringToDiskType(typeStr string) DiskType {
 		"HDD":  HDD,
 		"SSD":  SSD,
 		"NVME": NVME,
+		"FILE": TYPEFILE,
 	}
 	if dtype, ok := kmap[typeStr]; ok {
 		return dtype
@@ -104,26 +108,30 @@ const (
 
 	// XENBUS - xen blkfront
 	XENBUS
+
+	// FILESYSTEM - a file on a filesystem.
+	FILESYSTEM
 )
 
 func (t AttachmentType) String() string {
 	return []string{"UNKNOWN", "RAID", "SCSI", "ATA", "PCIE", "USB",
-		"VIRTIO", "IDE", "NBD", "LOOP", "XENBUS"}[t]
+		"VIRTIO", "IDE", "NBD", "LOOP", "XENBUS", "FILESYSTEM"}[t]
 }
 
 // StringToAttachmentType - Convert a string to an AttachmentType
 func StringToAttachmentType(atypeStr string) AttachmentType {
 	kmap := map[string]AttachmentType{
-		"UNKNOWN": UnknownAttach,
-		"RAID":    RAID,
-		"SCSI":    SCSI,
-		"ATA":     ATA,
-		"PCIE":    PCIE,
-		"VIRTIO":  VIRTIO,
-		"IDE":     IDE,
-		"NBD":     NBD,
-		"LOOP":    LOOP,
-		"XENBUS":  XENBUS,
+		"UNKNOWN":    UnknownAttach,
+		"RAID":       RAID,
+		"SCSI":       SCSI,
+		"ATA":        ATA,
+		"PCIE":       PCIE,
+		"VIRTIO":     VIRTIO,
+		"IDE":        IDE,
+		"NBD":        NBD,
+		"LOOP":       LOOP,
+		"XENBUS":     XENBUS,
+		"FILESYSTEM": FILESYSTEM,
 	}
 
 	if atype, ok := kmap[atypeStr]; ok {

--- a/linux/system_test.go
+++ b/linux/system_test.go
@@ -160,4 +160,13 @@ func TestCreatePartitions(t *testing.T) {
 
 	ast.Equal(part1, pSetFound[1])
 	ast.Equal(part2, pSetFound[2])
+
+	scannedDisk, err := sys.ScanDisk(disk.Path)
+	if err != nil {
+		t.Errorf("Failed to scan disk-image")
+	}
+
+	ast.Equal(disk.Size, scannedDisk.Size)
+	ast.Equal(disko.FILESYSTEM, scannedDisk.Attachment)
+	ast.Equal(disko.TYPEFILE, scannedDisk.Type)
 }


### PR DESCRIPTION
Please pull #112 first. this overlaps with some of it, so i've just put it on top of that.

    Support ScanDisk on files.
    
    Previously you needed to provide ScanDisk with a linux block device.
    It would fail if provided a file.  Now, it will return a disk{}
    structure that has AttachmentType of ATTACHFILE and DiskType
    of DISKFILE.
    
    All other information should be reasonably filled in.