### PR TITLE
Explicitly format luks devices with luks2.

### DIFF
--- a/linux/lvm.go
+++ b/linux/lvm.go
@@ -257,7 +257,7 @@ func (ls *linuxLVM) HasVG(vgName string) bool {
 func (ls *linuxLVM) CryptFormat(vgName string, lvName string, key string) error {
 	return runCommandStdin(
 		key,
-		"cryptsetup", "luksFormat", "--key-file=-", lvPath(vgName, lvName))
+		"cryptsetup", "luksFormat", "--type=luks2", "--key-file=-", lvPath(vgName, lvName))
 }
 
 func (ls *linuxLVM) CryptOpen(vgName string, lvName string,


### PR DESCRIPTION
Previously we were formating luks devices without a '--type='.
That left it up to the system default to be either luks1 or luks2.
Recent OS would be luks2, but older ones (centos 7) would be luks1.

We should be explicit.