### PR TITLE
Fix/do the zeros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-VERSION := $(shell x=$$(git describe --tags) && echo $${x\#v} || echo unknown)
+HASH = \#
+VERSION := $(shell x=$$(git describe --tags) && echo $${x$(HASH)v} || echo unknown)
 VERSION_SUFFIX := $(shell [ -z "$$(git status --porcelain --untracked-files=no)" ] || echo -dirty)
 VERSION_FULL := $(VERSION)$(VERSION_SUFFIX)
 LDFLAGS := "${ldflags:+$ldflags }-X main.version=${ver}${suff}"


### PR DESCRIPTION
Zero devices after lvcreate.

We are experiencing some issues where devices come back from lvcreate
(with --wipe-signatures=y --zero=y) that are not being zerod.
Specifically the problem that we're seeing is that luks metadata is
present as shown by both blkid and 'cryptsetup luksUUID'.  Further
inspection shows the beginning of the devices are simply notn being
wiped (the luks header string 'LUKS' is literally the first bytes of
the device)

The really ugly thing about this is that we do not have any logging.
So as this is, we're just Printf'ing to stderr the hopefully
recognizable string DISKO_LVCREATE_DID_NOT_ZERO.


Note: also snuck in a straightfoward Makefile change here for newer Make.