### PR TITLE
Wipe luks2 headers after lvcreate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS := "${ldflags:+$ldflags }-X main.version=${ver}${suff}"
 BUILD_FLAGS := -ldflags "-X main.version=$(VERSION_FULL)"
 ENV_ROOT := $(shell [ "$$(id -u)" = "0" ] && echo env || echo sudo )
 
-GOLANGCI_VER = v1.43.0
+GOLANGCI_VER = v1.47.2
 GOLANGCI = ./tools/golangci-lint-$(GOLANGCI_VER)
 
 CMDS := demo/demo ptimg/ptimg

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-VERSION := $(shell x=$$(git describe --tags) && echo $${x\#v} || echo unknown)
+HASH = \#
+VERSION := $(shell x=$$(git describe --tags) && echo $${x$(HASH)v} || echo unknown)
 VERSION_SUFFIX := $(shell [ -z "$$(git status --porcelain --untracked-files=no)" ] || echo -dirty)
 VERSION_FULL := $(VERSION)$(VERSION_SUFFIX)
 LDFLAGS := "${ldflags:+$ldflags }-X main.version=${ver}${suff}"


### PR DESCRIPTION
Wipe luks2 headers after lvcreate.

Versions of libblkid, before 2.33 would not completely wipe luks 2
headers.  After we create a thick LV, wipe any remaining headers
ourselves.

This should not be that big of a problem, but when it was mixed with
a liberal running of 'cryptsetup luksUUID' after LV creation things
went awry.  cryptsetup will automatically repair a broken header
that it finds, and it would find such a header because lvm did not
completely wipe it.  To be clear, 'cryptsetup luksUUID' is not
a read-only operation.

Also complicating things was the fact that we were creating luks 2
volumes and then running with an old LVM.


2 other changes snuck in here:
 * Update to newer lint.  v1.47.2 to support golang 1.18
 * Fix a Makefile error resulting in 'bad substitution'