### PR TITLE
Fix/pvcreate vgcreate force

### DIFF
--- a/linux/root_test.go
+++ b/linux/root_test.go
@@ -500,9 +500,14 @@ func TestRootLVMCreate(t *testing.T) {
 
 	lvm := linux.VolumeManager()
 
-	pv, err = lvm.CreatePV(disk.Path + "p1")
+	part1Path := disk.Path + "p1"
+	if err := runCommand("mkfs.ext4", "-F", part1Path); err != nil {
+		t.Errorf("Failed to mkfs on %s: %s", part1Path, err)
+	}
+
+	pv, err = lvm.CreatePV(part1Path)
 	if err != nil {
-		t.Fatalf("Failed to create pv on %s: %s\n", disk.Path, err)
+		t.Fatalf("Failed to create pv on %s: %s\n", part1Path, err)
 	}
 
 	cl.AddF(func() error { return lvm.DeletePV(pv) }, "remove pv")


### PR DESCRIPTION
 * Add --force to pvcreate, vgcreate and vgextend.

    pvcreate, vgcreate and vgextend need the --force flag, or they
    will exit failure if there the provided block device has known
    filesystem metadata.

 * Change TestRootLVMCreate to mkfs the partition before PVCreate.

    Without the fix in the previous commit to use '--force' to pvcreate,
    the test case TestRootLVMCreate will now fail like:

    ```
    root_test.go:510: Failed to create pv on /dev/loop27p1:
     command returned 5:
    cmd: [lvm pvcreate --zero=y --metadatasize=134217728B /dev/loop27p1]
    err: WARNING: ext4 signature detected on /dev/loop27p1 at
         offset 1080. Wipe it? [y/n]: [n]
    Aborted wiping of ext4.
    1 existing signature left on the device.
    ```
