### PR TITLE
Use --force twice and add --yes in calls to pvremove.

### DIFF
--- a/linux/lvm.go
+++ b/linux/lvm.go
@@ -194,7 +194,7 @@ func (ls *linuxLVM) CreatePV(name string) (disko.PV, error) {
 }
 
 func (ls *linuxLVM) DeletePV(pv disko.PV) error {
-	return runCommandSettled("lvm", "pvremove", "--force", pv.Path)
+	return runCommandSettled("lvm", "pvremove", "--force", "--force", "--yes", pv.Path)
 }
 
 func (ls *linuxLVM) HasPV(name string) bool {


### PR DESCRIPTION
There was a case we hit where LVM was in a bad state and in order to remove a PV it wanted you to use --force twice and would *still* prompt.  The LVM in use was from Ubuntu 22.04 (2.03.11).

I'm not able to easily add a test for this because the LVM state isn't easily created (it included broken state as seen below):

    $ pvs
    WARNING: PV /dev/sdf5 is marked in use but no VG was found using it.
    WARNING: PV /dev/sdf5 might need repairing.
    PV         VG        Fmt  Attr PSize   PFree
    /dev/sdf5  [unknown] lvm2 u--  150.00g    0

    $ lvm pvremove --force --force --verbose --debug /dev/sdf5
    WARNING: PV /dev/sdf5 is used by VG <unknown>.
      Really WIPE LABELS from physical volume "/dev/sdf5" of
         volume group "<unknown>" [y/n]? yes
    Accepted input: [y]
    WARNING: Wiping physical volume label from /dev/sdf5 of
      volume group "<unknown>".
    Labels on physical volume "/dev/sdf5" successfully wiped.